### PR TITLE
Web: Fix dolt init errors

### DIFF
--- a/web/build/builder-dmg-config.yaml
+++ b/web/build/builder-dmg-config.yaml
@@ -3,7 +3,7 @@ directories:
   buildResources: build
 appId: com.dolthub.dolt-workbench
 productName: DoltWorkbench
-buildVersion: 0.3.10
+buildVersion: 0.3.12
 copyright: Copyright © 2024 <DoltHub Inc>
 files:
   - filter:

--- a/web/build/builder-dmg-config.yaml
+++ b/web/build/builder-dmg-config.yaml
@@ -3,7 +3,7 @@ directories:
   buildResources: build
 appId: com.dolthub.dolt-workbench
 productName: DoltWorkbench
-buildVersion: 0.3.9
+buildVersion: 0.3.10
 copyright: Copyright © 2024 <DoltHub Inc>
 files:
   - filter:

--- a/web/build/builder-mas-config.yaml
+++ b/web/build/builder-mas-config.yaml
@@ -3,7 +3,7 @@ directories:
   buildResources: build
 appId: com.dolthub.dolt-workbench
 productName: Dolt Workbench
-buildVersion: 0.3.9
+buildVersion: 0.3.10
 copyright: Copyright © 2024 <DoltHub Inc>
 files:
   - filter:

--- a/web/build/builder-mas-config.yaml
+++ b/web/build/builder-mas-config.yaml
@@ -2,8 +2,8 @@ directories:
   output: dist
   buildResources: build
 appId: com.dolthub.dolt-workbench
-productName: Dolt Workbench
-buildVersion: 0.3.10
+productName: DoltWorkbench
+buildVersion: 0.3.12
 copyright: Copyright © 2024 <DoltHub Inc>
 files:
   - filter:

--- a/web/build/builder-win-config.yaml
+++ b/web/build/builder-win-config.yaml
@@ -2,8 +2,8 @@ directories:
   output: dist
   buildResources: build
 appId: com.dolthub.dolt-workbench
-productName: Dolt-Workbench
-buildVersion: 0.3.10
+productName: DoltWorkbench
+buildVersion: 0.3.12
 copyright: Copyright © 2024 DoltHub Inc
 icon: build/appx/icon.ico
 files:

--- a/web/build/builder-win-config.yaml
+++ b/web/build/builder-win-config.yaml
@@ -3,7 +3,7 @@ directories:
   buildResources: build
 appId: com.dolthub.dolt-workbench
 productName: Dolt-Workbench
-buildVersion: 0.3.9
+buildVersion: 0.3.10
 copyright: Copyright © 2024 DoltHub Inc
 icon: build/appx/icon.ico
 files:

--- a/web/main/doltServer.ts
+++ b/web/main/doltServer.ts
@@ -89,7 +89,7 @@ function initializeDoltRepository(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     exec(
-      `${doltPath} init`,
+      `${doltPath} init --name 'local_user' --email 'user@local.com'`,
       { cwd: dbFolderPath },
       async (error, stdout, stderr) => {
         if (error) {

--- a/web/main/doltServer.ts
+++ b/web/main/doltServer.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { app, BrowserWindow } from "electron";
+import { rimraf } from "rimraf";
 import { ChildProcess, exec, spawn } from "child_process";
 
 type ErrorReturnType = {
@@ -192,7 +193,11 @@ export async function removeDoltServerFolder(
 ): Promise<ErrorReturnType> {
   for (let i = 0; i < retries; i++) {
     try {
-      await fs.promises.rm(dbFolderPath, { recursive: true, force: true });
+      if (process.platform === "darwin") {
+        await fs.promises.rm(dbFolderPath, { recursive: true, force: true });
+      } else {
+        await rimraf(dbFolderPath);
+      }
       return { errorMsg: undefined };
     } catch (err) {
       if (i === retries - 1) {

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "dolt-workbench",
   "description": "SQL workbench for MySQL and PostgreSQL databases",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "main": "app/background.js",
   "author": "DoltHub",
   "packageManager": "yarn@4.5.0",

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "dolt-workbench",
   "description": "SQL workbench for MySQL and PostgreSQL databases",
-  "version": "0.3.10",
+  "version": "0.3.12",
   "main": "app/background.js",
   "author": "DoltHub",
   "packageManager": "yarn@4.5.0",

--- a/web/renderer/components/pageComponents/ConnectionsPage/NewConnection/StartDoltServerForm.tsx
+++ b/web/renderer/components/pageComponents/ConnectionsPage/NewConnection/StartDoltServerForm.tsx
@@ -91,7 +91,10 @@ function getStartLocalDoltServerDisabled(
   const disabled =
     !state.name ||
     !state.port ||
-    !!connections?.some(connection => connection.isLocalDolt);
+    !!connections?.some(
+      connection =>
+        connection.isLocalDolt || connections?.some(c => c.name === state.name),
+    );
   if (!disabled) {
     return { disabled };
   }
@@ -113,6 +116,12 @@ function getStartLocalDoltServerDisabled(
           </p>
         </div>
       ),
+    };
+  }
+  if (connections?.some(c => c.name === state.name)) {
+    return {
+      disabled,
+      message: <span>Connection name already exists.</span>,
     };
   }
   return { disabled };

--- a/web/renderer/components/pageComponents/ConnectionsPage/NewConnection/StartDoltServerForm.tsx
+++ b/web/renderer/components/pageComponents/ConnectionsPage/NewConnection/StartDoltServerForm.tsx
@@ -91,10 +91,9 @@ function getStartLocalDoltServerDisabled(
   const disabled =
     !state.name ||
     !state.port ||
-    !!connections?.some(
-      connection =>
-        connection.isLocalDolt || connections?.some(c => c.name === state.name),
-    );
+    !!connections?.some(connection => connection.isLocalDolt) ||
+    !!connections?.some(c => c.name === state.name);
+
   if (!disabled) {
     return { disabled };
   }

--- a/web/renderer/components/pageComponents/ConnectionsPage/NewConnection/context/config.tsx
+++ b/web/renderer/components/pageComponents/ConnectionsPage/NewConnection/context/config.tsx
@@ -44,6 +44,7 @@ export function ConfigProvider({ children }: Props) {
 
   useEffect(() => {
     if (!res.err) return;
+    setErr(res.err);
     if (
       res.err.message.includes("The server does not support SSL connections")
     ) {


### PR DESCRIPTION
Fixes:
- remove the empty space in product name to fix command-line parsing errors.
- add default name and email in `dolt init` command, related dolt issue: https://github.com/dolthub/dolt/issues/8835
- show addDatabaseConnection error when starting a dolt server

versioning:
last release: `0.3.10`.
 `0.3.11`: submitted to mac store to temporarily hide the dolt server feature. 
this pr release will be `0.3.12`.