### PR TITLE
Update browserlist, remove postbuild script temporarily

### DIFF
--- a/graphql-server/yarn.lock
+++ b/graphql-server/yarn.lock
@@ -3925,17 +3925,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001646":
-  version: 1.0.30001653
-  resolution: "caniuse-lite@npm:1.0.30001653"
-  checksum: 10c0/7aedf037541c93744148f599daea93d46d1f93ab4347997189efa2d1f003af8eadd7e1e05347ef09261ac1dc635ce375b8c6c00796245fffb4120a124824a14f
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001688":
-  version: 1.0.30001690
-  resolution: "caniuse-lite@npm:1.0.30001690"
-  checksum: 10c0/646bd469032afa90400a84dec30a2b00a6eda62c03ead358117e3f884cda8aacec02ec058a6dbee5eaf9714f83e483b9b0eb4fb42febb8076569f5ca40f1d347
+"caniuse-lite@npm:^1.0.30001646, caniuse-lite@npm:^1.0.30001688":
+  version: 1.0.30001715
+  resolution: "caniuse-lite@npm:1.0.30001715"
+  checksum: 10c0/0109a7da797ffbe1aa197baa5242b205011098eecec1087ef3d0c58ceea19be325ab6679b2751a78660adc3051a9f77e99d5789938fd1eb1235e6fdf6a1dbf8e
   languageName: node
   linkType: hard
 

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,6 @@
     "build:mas": "nextron build --config ./build/builder-mas-config.yaml",
     "build:win": "nextron build --win --x64 --config ./build/builder-win-config.yaml",
     "postinstall": "electron-builder install-app-deps",
-    "postbuild": "chmod +x build/mac/dolt",
     "prettier": "prettier --check 'renderer/{components,contexts,hooks,lib,pages}/**/*.{js,ts,jsx,tsx,css}' 'main/*.{js,ts,jsx,tsx}' 'main/**/*.{js,ts,jsx,tsx}'",
     "prettier-fix": "prettier --write 'renderer/{components,contexts,hooks,lib,pages}/**/*.{js,ts,jsx,tsx,css}' 'main/*.{js,ts,jsx,tsx}' 'main/**/*.{js,ts,jsx,tsx}'",
     "lint": "yarn lint-js-errors && yarn lint-css",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -7463,17 +7463,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001646, caniuse-lite@npm:^1.0.30001663":
-  version: 1.0.30001669
-  resolution: "caniuse-lite@npm:1.0.30001669"
-  checksum: 10c0/f125f23440d3dbb6c25ffb8d55f4ce48af36a84d0932b152b3b74f143a4170cbe92e02b0a9676209c86609bf7bf34119ff10cc2bc7c1b7ea40e936cc16598408
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001669":
-  version: 1.0.30001684
-  resolution: "caniuse-lite@npm:1.0.30001684"
-  checksum: 10c0/446485ca3d9caf408a339a44636a86a2b119ec247492393ae661cd93dccd6668401dd2dfec1e149be4e44563cd1e23351b44453a52fa2c2f19e2bf3287c865f6
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001646, caniuse-lite@npm:^1.0.30001663, caniuse-lite@npm:^1.0.30001669":
+  version: 1.0.30001715
+  resolution: "caniuse-lite@npm:1.0.30001715"
+  checksum: 10c0/0109a7da797ffbe1aa197baa5242b205011098eecec1087ef3d0c58ceea19be325ab6679b2751a78660adc3051a9f77e99d5789938fd1eb1235e6fdf6a1dbf8e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The `postbuild` script is causing the docker build to fail with
```
#32 163.0 $ chmod +x build/mac/dolt
#32 163.0 chmod: build/mac/dolt: No such file or directory
```
Removing it temporarily until we know how to fix