### PR TITLE
graphql,web: Simple resolve conflicts from the web

### DIFF
--- a/graphql-server/schema.gql
+++ b/graphql-server/schema.gql
@@ -416,6 +416,7 @@ type Mutation {
   doltClone(databaseName: String!, ownerName: String!, remoteDbName: String!): Boolean!
   loadDataFile(schemaName: String, tableName: String!, refName: String!, databaseName: String!, importOp: ImportOperation!, fileType: FileType!, file: Upload!, modifier: LoadDataModifier): Boolean!
   mergePull(fromBranchName: String!, toBranchName: String!, databaseName: String!, author: AuthorInfo): Boolean!
+  mergeAndResolveConflicts(author: AuthorInfo, fromBranchName: String!, toBranchName: String!, databaseName: String!, conflictResolveType: ConflictResolveType!): Boolean!
   addRemote(remoteName: String!, databaseName: String!, remoteUrl: String!): String!
   deleteRemote(databaseName: String!, remoteName: String!): Boolean!
   pullFromRemote(remoteName: String!, databaseName: String!, refName: String!, branchName: String!): PullRes!
@@ -448,4 +449,9 @@ enum LoadDataModifier {
 input AuthorInfo {
   name: String!
   email: String!
+}
+
+enum ConflictResolveType {
+  Ours
+  Theirs
 }

--- a/graphql-server/src/pulls/pull.enums.ts
+++ b/graphql-server/src/pulls/pull.enums.ts
@@ -7,3 +7,10 @@ export enum PullState {
 }
 
 registerEnumType(PullState, { name: "PullState" });
+
+export enum ConflictResolveType {
+  Ours = "ours",
+  Theirs = "theirs",
+}
+
+registerEnumType(ConflictResolveType, { name: "ConflictResolveType" });

--- a/graphql-server/src/pulls/pull.resolver.ts
+++ b/graphql-server/src/pulls/pull.resolver.ts
@@ -9,12 +9,19 @@ import {
 import { CommitResolver } from "../commits/commit.resolver";
 import { ConnectionProvider } from "../connections/connection.provider";
 import { AuthorInfo, PullArgs } from "../utils/commonTypes";
+import { ConflictResolveType } from "./pull.enums";
 import { PullWithDetails, fromAPIModelPullWithDetails } from "./pull.model";
 
 @ArgsType()
 class MergePullArgs extends PullArgs {
   @Field({ nullable: true })
   author?: AuthorInfo;
+}
+
+@ArgsType()
+class MergeAndResolveArgs extends MergePullArgs {
+  @Field(_type => ConflictResolveType)
+  conflictResolveType: ConflictResolveType;
 }
 
 @Resolver(_of => PullWithDetails)
@@ -45,6 +52,21 @@ export class PullResolver {
       fromBranchName: args.fromBranchName,
       toBranchName: args.toBranchName,
       author: args.author,
+    });
+    return true;
+  }
+
+  @Mutation(_returns => Boolean)
+  async mergeAndResolveConflicts(
+    @Args() args: MergeAndResolveArgs,
+  ): Promise<boolean> {
+    const conn = this.conn.connection();
+    await conn.callMergeWithResolveConflicts({
+      databaseName: args.databaseName,
+      fromBranchName: args.fromBranchName,
+      toBranchName: args.toBranchName,
+      author: args.author,
+      conflictResolveType: args.conflictResolveType,
     });
     return true;
   }

--- a/graphql-server/src/queryFactory/dolt/index.ts
+++ b/graphql-server/src/queryFactory/dolt/index.ts
@@ -335,6 +335,7 @@ export class DoltQueryFactory
     return this.queryMultiple(
       async query => {
         await query("BEGIN");
+        await query("SET @autocommit = 0");
 
         const msg = `Merge branch ${args.fromBranchName}`;
         const params = [msg];
@@ -350,9 +351,11 @@ export class DoltQueryFactory
           await query(qh.resolveConflicts, [`--${args.conflictResolveType}`]);
           await query(qh.getCommitMerge(!!args.author), params);
         } else {
+          await query("ROLLBACK");
           throw new Error("expected conflicts but none found");
         }
 
+        await query("COMMIT");
         return true;
       },
       args.databaseName,

--- a/graphql-server/src/queryFactory/dolt/index.ts
+++ b/graphql-server/src/queryFactory/dolt/index.ts
@@ -326,6 +326,40 @@ export class DoltQueryFactory
     );
   }
 
+  async callMergeWithResolveConflicts(
+    args: t.BranchesArgs & {
+      author?: t.CommitAuthor;
+      conflictResolveType: string;
+    },
+  ): Promise<boolean> {
+    return this.queryMultiple(
+      async query => {
+        await query("BEGIN");
+
+        const msg = `Merge branch ${args.fromBranchName}`;
+        const params = [msg];
+        if (args.author) {
+          params.push(getAuthorString(args.author));
+        }
+        const res = await query(qh.getCallMerge(!!args.author), [
+          args.fromBranchName,
+          ...params,
+        ]);
+
+        if (res.length && res[0].conflicts !== "0") {
+          await query(qh.resolveConflicts, [`--${args.conflictResolveType}`]);
+          await query(qh.getCommitMerge(!!args.author), params);
+        } else {
+          throw new Error("expected conflicts but none found");
+        }
+
+        return true;
+      },
+      args.databaseName,
+      args.toBranchName,
+    );
+  }
+
   async resolveRefs(
     args: t.RefsArgs & { type?: CommitDiffType },
   ): t.CommitsRes {

--- a/graphql-server/src/queryFactory/dolt/queries.ts
+++ b/graphql-server/src/queryFactory/dolt/queries.ts
@@ -87,6 +87,11 @@ export const mergeConflictsSummaryQuery = `SELECT * FROM DOLT_PREVIEW_MERGE_CONF
 
 export const mergeConflictsQuery = `SELECT * FROM DOLT_PREVIEW_MERGE_CONFLICTS(?, ?, ?) LIMIT ? OFFSET ?`;
 
+export const resolveConflicts = `CALL DOLT_CONFLICTS_RESOLVE(?, '.')`;
+
+export const getCommitMerge = (hasAuthor = false) =>
+  `CALL DOLT_COMMIT("-Am", ?${getAuthorNameString(hasAuthor)})`;
+
 // REMOTES
 
 export const callAddRemote = `CALL DOLT_REMOTE("add", ?, ?)`;

--- a/graphql-server/src/queryFactory/doltgres/index.ts
+++ b/graphql-server/src/queryFactory/doltgres/index.ts
@@ -345,7 +345,7 @@ export class DoltgresQueryFactory
     return this.queryMultiple(
       async query => {
         await query("BEGIN");
-        await query("SET autocommit TO 0");
+        // await query("SET autocommit off");
 
         const msg = `Merge branch ${args.fromBranchName}`;
         const params = [msg];

--- a/graphql-server/src/queryFactory/doltgres/index.ts
+++ b/graphql-server/src/queryFactory/doltgres/index.ts
@@ -345,6 +345,7 @@ export class DoltgresQueryFactory
     return this.queryMultiple(
       async query => {
         await query("BEGIN");
+        await query("SET autocommit TO 0");
 
         const msg = `Merge branch ${args.fromBranchName}`;
         const params = [msg];
@@ -360,9 +361,11 @@ export class DoltgresQueryFactory
           await query(qh.resolveConflicts, [`--${args.conflictResolveType}`]);
           await query(qh.getCommitMerge(!!args.author), params);
         } else {
+          await query("ROLLBACK");
           throw new Error("expected conflicts but none found");
         }
 
+        await query("COMMIT");
         return true;
       },
       args.databaseName,

--- a/graphql-server/src/queryFactory/doltgres/queries.ts
+++ b/graphql-server/src/queryFactory/doltgres/queries.ts
@@ -95,6 +95,11 @@ export const mergeConflictsSummaryQuery = `SELECT * FROM DOLT_PREVIEW_MERGE_CONF
 export const getMergeConflictsQuery = (offset: number) =>
   `SELECT * FROM DOLT_PREVIEW_MERGE_CONFLICTS($1::text, $2::text, $3::text) LIMIT ${ROW_LIMIT + 1} OFFSET ${offset}`;
 
+export const resolveConflicts = `SELECT DOLT_CONFLICTS_RESOLVE($1::text, '.')`;
+
+export const getCommitMerge = (hasAuthor = false) =>
+  `CALL DOLT_COMMIT("-Am", $1::text${getAuthorNameString(hasAuthor, "$2::text")})`;
+
 // TAGS
 
 export const callDeleteTag = `SELECT DOLT_TAG('-d', $1::text)`;

--- a/graphql-server/src/queryFactory/index.ts
+++ b/graphql-server/src/queryFactory/index.ts
@@ -139,6 +139,13 @@ export declare class QueryFactory {
     args: t.BranchesArgs & { author?: t.CommitAuthor },
   ): Promise<boolean>;
 
+  callMergeWithResolveConflicts(
+    args: t.BranchesArgs & {
+      author?: t.CommitAuthor;
+      conflictResolveType: string;
+    },
+  ): Promise<boolean>;
+
   resolveRefs(
     args: t.RefsArgs & { type?: CommitDiffType },
   ): Promise<{ fromCommitId: string; toCommitId: string }>;

--- a/graphql-server/src/queryFactory/mysql/index.ts
+++ b/graphql-server/src/queryFactory/mysql/index.ts
@@ -298,6 +298,10 @@ export class MySQLQueryFactory
     throw notDoltError("merge branches");
   }
 
+  async callMergeWithResolveConflicts(_: t.BranchesArgs): Promise<boolean> {
+    throw notDoltError("merge branches with conflicts");
+  }
+
   async resolveRefs(
     args: t.RefsArgs,
   ): Promise<{ fromCommitId: string; toCommitId: string }> {

--- a/web/renderer/components/pageComponents/ConnectionsPage/ExistingConnections/Item.tsx
+++ b/web/renderer/components/pageComponents/ConnectionsPage/ExistingConnections/Item.tsx
@@ -1,13 +1,13 @@
+import { DatabaseTypeLabel } from "@components/ConnectionsAndDatabases/DatabaseTypeLabel";
 import { getDatabaseType } from "@components/DatabaseTypeLabel";
 import { Button, ErrorMsg, Loader } from "@dolthub/react-components";
 import { DatabaseConnectionFragment } from "@gen/graphql-types";
 import { IoMdClose } from "@react-icons/all-files/io/IoMdClose";
+import cx from "classnames";
 import Image from "next/legacy/image";
 import { SyntheticEvent, useState } from "react";
-import cx from "classnames";
-import { DatabaseTypeLabel } from "@components/ConnectionsAndDatabases/DatabaseTypeLabel";
-import useAddConnection from "./useAddConnection";
 import css from "./index.module.css";
+import useAddConnection from "./useAddConnection";
 
 const forElectron = process.env.NEXT_PUBLIC_FOR_ELECTRON === "true";
 
@@ -84,7 +84,7 @@ export default function Item({
                 {conn.name}
               </Button.Link>
             </div>
-            <ErrorMsg err={err || startDoltServerError} className={css.err} />
+            <ErrorMsg err={err ?? startDoltServerError} className={css.err} />
           </div>
         </div>
       </li>

--- a/web/renderer/components/pageComponents/ConnectionsPage/ExistingConnections/index.module.css
+++ b/web/renderer/components/pageComponents/ConnectionsPage/ExistingConnections/index.module.css
@@ -115,7 +115,7 @@
 }
 
 .err {
-  @apply text-center;
+  @apply text-center pt-0;
 }
 
 .leftLine {

--- a/web/renderer/components/pageComponents/ConnectionsPage/ExistingConnections/useAddConnection.ts
+++ b/web/renderer/components/pageComponents/ConnectionsPage/ExistingConnections/useAddConnection.ts
@@ -3,6 +3,7 @@ import {
   useAddDatabaseConnectionMutation,
   useDoltServerStatusQuery,
 } from "@gen/graphql-types";
+import useMutation from "@hooks/useMutation";
 import { ApolloErrorType } from "@lib/errors/types";
 import { maybeDatabase } from "@lib/urls";
 import { useRouter } from "next/router";
@@ -18,19 +19,23 @@ export default function useAddConnection(
   conn: DatabaseConnectionFragment,
 ): ReturnType {
   const router = useRouter();
-  const [addDb, res] = useAddDatabaseConnectionMutation();
+  const { mutateFn: addDb, ...res } = useMutation({
+    hook: useAddDatabaseConnectionMutation,
+  });
   const doltServerStatus = useDoltServerStatusQuery({
     variables: conn,
   });
+
   const onAdd = async () => {
     try {
-      const db = await addDb({ variables: conn });
-      await res.client.clearStore();
-      if (!db.data) {
+      const { data, success } = await addDb({ variables: conn });
+      if (!success || !data) {
         return;
       }
+      await res.client.cache.reset();
+
       const { href, as } = maybeDatabase(
-        db.data.addDatabaseConnection.currentDatabase,
+        data.addDatabaseConnection.currentDatabase,
       );
       router.push(href, as).catch(console.error);
     } catch {
@@ -40,7 +45,7 @@ export default function useAddConnection(
 
   return {
     onAdd,
-    err: res.error || doltServerStatus.error,
+    err: res.err ?? doltServerStatus.error,
     loading: res.loading,
     doltServerIsActive: !!doltServerStatus.data?.doltServerStatus.active,
   };

--- a/web/renderer/components/pageComponents/DatabasePage/ForPullConflicts/ConflictsTable/index.tsx
+++ b/web/renderer/components/pageComponents/DatabasePage/ForPullConflicts/ConflictsTable/index.tsx
@@ -89,7 +89,7 @@ export default function ConflictsTable(props: Props) {
           </table>
         </InfiniteScroll>
       ) : (
-        <p className={css.noChanges}>No conflicts for this table</p>
+        <p className={css.noChanges}>No data conflicts for this table</p>
       )}
     </div>
   );

--- a/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/ResolveModal.tsx
+++ b/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/ResolveModal.tsx
@@ -1,0 +1,62 @@
+import Link from "@components/links/Link";
+import { Button, ExternalLink, Modal, Radio } from "@dolthub/react-components";
+import { ConflictResolveType } from "@gen/graphql-types";
+import { ModalProps } from "@lib/modalProps";
+import { PullDiffParams } from "@lib/params";
+import { pullConflicts } from "@lib/urls";
+import { useState } from "react";
+import css from "./index.module.css";
+
+type Props = ModalProps & {
+  onClickWithResolve: (resolveType: ConflictResolveType) => Promise<void>;
+  params: PullDiffParams;
+};
+
+export default function ResolveModal(props: Props) {
+  const [resType, setResType] = useState<ConflictResolveType>(
+    ConflictResolveType.Ours,
+  );
+
+  return (
+    <Modal
+      title="Resolve Conflicts and Merge"
+      isOpen={props.isOpen}
+      onRequestClose={() => props.setIsOpen(false)}
+      className={css.modal}
+      button={
+        <Button onClick={async () => await props.onClickWithResolve(resType)}>
+          Choose {resType.toLowerCase()} and merge
+        </Button>
+      }
+    >
+      <div>
+        <p>
+          To merge this pull request, choose a conflict resolution strategy:
+        </p>
+        <Radio
+          label="Use ours"
+          name="ours"
+          checked={resType === ConflictResolveType.Ours}
+          onChange={() => setResType(ConflictResolveType.Ours)}
+        />
+        <Radio
+          label="Use theirs"
+          name="theirs"
+          checked={resType === ConflictResolveType.Theirs}
+          onChange={() => setResType(ConflictResolveType.Theirs)}
+        />
+        <p>
+          You can view the table conflicts before merging{" "}
+          <Link {...pullConflicts(props.params)}>here</Link>.
+        </p>
+        <p>
+          If you&apos;d like more granular conflict resolution, see{" "}
+          <ExternalLink href="https://www.dolthub.com/blog/2021-03-15-programmatic-merge-and-resolve/">
+            this guide
+          </ExternalLink>
+          .
+        </p>
+      </div>
+    </Modal>
+  );
+}

--- a/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/ResolveModal.tsx
+++ b/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/ResolveModal.tsx
@@ -1,6 +1,13 @@
 import Link from "@components/links/Link";
-import { Button, ExternalLink, Modal, Radio } from "@dolthub/react-components";
+import {
+  Button,
+  ErrorMsg,
+  ExternalLink,
+  Modal,
+  Radio,
+} from "@dolthub/react-components";
 import { ConflictResolveType } from "@gen/graphql-types";
+import { ApolloErrorType } from "@lib/errors/types";
 import { ModalProps } from "@lib/modalProps";
 import { PullDiffParams } from "@lib/params";
 import { pullConflicts } from "@lib/urls";
@@ -10,6 +17,7 @@ import css from "./index.module.css";
 type Props = ModalProps & {
   onClickWithResolve: (resolveType: ConflictResolveType) => Promise<void>;
   params: PullDiffParams;
+  err?: ApolloErrorType;
 };
 
 export default function ResolveModal(props: Props) {
@@ -24,7 +32,10 @@ export default function ResolveModal(props: Props) {
       onRequestClose={() => props.setIsOpen(false)}
       className={css.modal}
       button={
-        <Button onClick={async () => await props.onClickWithResolve(resType)}>
+        <Button
+          onClick={async () => await props.onClickWithResolve(resType)}
+          disabled={!!props.err}
+        >
           Choose {resType.toLowerCase()} and merge
         </Button>
       }
@@ -56,6 +67,7 @@ export default function ResolveModal(props: Props) {
           </ExternalLink>
           .
         </p>
+        <ErrorMsg err={props.err} />
       </div>
     </Modal>
   );

--- a/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/index.module.css
+++ b/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/index.module.css
@@ -150,3 +150,11 @@
 .conflictsLoader {
   @apply mb-2 ml-0;
 }
+
+.modal {
+  @apply text-primary;
+
+  p {
+    @apply my-3;
+  }
+}

--- a/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/index.module.css
+++ b/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/index.module.css
@@ -157,4 +157,8 @@
   p {
     @apply my-3;
   }
+
+  h3 {
+    @apply my-0;
+  }
 }

--- a/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/index.tsx
+++ b/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/index.tsx
@@ -1,6 +1,7 @@
 import HeaderUserCheckbox from "@components/HeaderUserCheckbox";
 import { Button, SmallLoader } from "@dolthub/react-components";
 import { ConflictResolveType, PullDetailsFragment } from "@gen/graphql-types";
+import useDatabaseDetails from "@hooks/useDatabaseDetails";
 import { ApolloErrorType } from "@lib/errors/types";
 import { PullDiffParams } from "@lib/params";
 import { FiGitPullRequest } from "@react-icons/all-files/fi/FiGitPullRequest";
@@ -109,10 +110,11 @@ type MergeButtonProps = {
 
 function MergeButton(props: MergeButtonProps) {
   const [modalOpen, setModalOpen] = useState(false);
+  const { isPostgres } = useDatabaseDetails();
 
   return (
     <div aria-label="merge-button-container">
-      {props.disabled ? (
+      {props.disabled && !isPostgres ? (
         <>
           <Button
             className={css.merge}
@@ -132,6 +134,7 @@ function MergeButton(props: MergeButtonProps) {
           className={css.merge}
           onClick={props.onClick}
           data-cy="merge-button"
+          disabled={props.disabled}
           green
         >
           {props.loading ? "Merging..." : "Merge"}

--- a/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/index.tsx
+++ b/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/index.tsx
@@ -1,6 +1,7 @@
 import HeaderUserCheckbox from "@components/HeaderUserCheckbox";
 import { Button, SmallLoader } from "@dolthub/react-components";
 import { ConflictResolveType, PullDetailsFragment } from "@gen/graphql-types";
+import { ApolloErrorType } from "@lib/errors/types";
 import { PullDiffParams } from "@lib/params";
 import { FiGitPullRequest } from "@react-icons/all-files/fi/FiGitPullRequest";
 import cx from "classnames";
@@ -31,6 +32,7 @@ export default function Merge(props: Props) {
     state,
     setState,
     mergeState,
+    resolveState,
   } = useMergeButton(props.params);
   const red = hasConflicts;
 
@@ -47,7 +49,8 @@ export default function Merge(props: Props) {
             disabled={disabled}
             onClick={onClick}
             onClickWithResolve={onClickWithResolve}
-            loading={mergeState.loading}
+            loading={resolveState.loading}
+            err={resolveState.err}
             params={props.params}
           />
           {mergeState.err && (
@@ -101,6 +104,7 @@ type MergeButtonProps = {
   onClickWithResolve: (resolveType: ConflictResolveType) => Promise<void>;
   loading: boolean;
   params: PullDiffParams;
+  err?: ApolloErrorType;
 };
 
 function MergeButton(props: MergeButtonProps) {
@@ -118,10 +122,9 @@ function MergeButton(props: MergeButtonProps) {
             {props.loading ? "Merging..." : "Resolve conflicts and merge"}
           </Button>
           <ResolveModal
+            {...props}
             isOpen={modalOpen}
             setIsOpen={setModalOpen}
-            onClickWithResolve={props.onClickWithResolve}
-            params={props.params}
           />
         </>
       ) : (

--- a/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/index.tsx
+++ b/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/index.tsx
@@ -1,14 +1,16 @@
 import HeaderUserCheckbox from "@components/HeaderUserCheckbox";
 import { Button, SmallLoader } from "@dolthub/react-components";
-import { PullDetailsFragment } from "@gen/graphql-types";
+import { ConflictResolveType, PullDetailsFragment } from "@gen/graphql-types";
 import { PullDiffParams } from "@lib/params";
 import { FiGitPullRequest } from "@react-icons/all-files/fi/FiGitPullRequest";
 import cx from "classnames";
+import { useState } from "react";
 import { Arrow } from "./Arrow";
 import ErrorsWithDirections from "./ErrorsWithDirections";
 import MergeConflictsDirections from "./ErrorsWithDirections/MergeConflictsDirections";
 import MergeConflicts from "./MergeConflicts";
 import MergeMessageTitle from "./MergeMessageTitle";
+import ResolveModal from "./ResolveModal";
 import css from "./index.module.css";
 import useMergeButton from "./useMergeButton";
 
@@ -17,11 +19,12 @@ type Props = {
   pullDetails: PullDetailsFragment;
 };
 
-export default function MergeButton(props: Props) {
+export default function Merge(props: Props) {
   const {
     hasConflicts,
     conflictsLoading,
     onClick,
+    onClickWithResolve,
     disabled,
     userHeaders,
     pullConflictsSummary,
@@ -40,17 +43,13 @@ export default function MergeButton(props: Props) {
       <div className={css.container}>
         <div className={cx(css.top, { [css.red]: red })}>
           <MergeMessageTitle hasConflicts={hasConflicts} />
-          <div aria-label="merge-button-container">
-            <Button
-              className={css.merge}
-              onClick={onClick}
-              disabled={disabled}
-              data-cy="merge-button"
-              green
-            >
-              {mergeState.loading ? "Merging..." : "Merge"}
-            </Button>
-          </div>
+          <MergeButton
+            disabled={disabled}
+            onClick={onClick}
+            onClickWithResolve={onClickWithResolve}
+            loading={mergeState.loading}
+            params={props.params}
+          />
           {mergeState.err && (
             <ErrorsWithDirections
               mergeErr={mergeState.err}
@@ -92,6 +91,49 @@ export default function MergeButton(props: Props) {
           {state.showDirections && <MergeConflictsDirections {...props} />}
         </div>
       </div>
+    </div>
+  );
+}
+
+type MergeButtonProps = {
+  disabled: boolean;
+  onClick: () => Promise<void>;
+  onClickWithResolve: (resolveType: ConflictResolveType) => Promise<void>;
+  loading: boolean;
+  params: PullDiffParams;
+};
+
+function MergeButton(props: MergeButtonProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  return (
+    <div aria-label="merge-button-container">
+      {props.disabled ? (
+        <>
+          <Button
+            className={css.merge}
+            onClick={() => setModalOpen(true)}
+            data-cy="merge-resolve-button"
+          >
+            {props.loading ? "Merging..." : "Resolve conflicts and merge"}
+          </Button>
+          <ResolveModal
+            isOpen={modalOpen}
+            setIsOpen={setModalOpen}
+            onClickWithResolve={props.onClickWithResolve}
+            params={props.params}
+          />
+        </>
+      ) : (
+        <Button
+          className={css.merge}
+          onClick={props.onClick}
+          data-cy="merge-button"
+          green
+        >
+          {props.loading ? "Merging..." : "Merge"}
+        </Button>
+      )}
     </div>
   );
 }

--- a/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/queries.ts
+++ b/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/queries.ts
@@ -16,6 +16,24 @@ export const MERGE_PULL = gql`
   }
 `;
 
+export const MERGE_AND_RESOLVE = gql`
+  mutation MergeAndResolveConflicts(
+    $databaseName: String!
+    $fromBranchName: String!
+    $toBranchName: String!
+    $conflictResolveType: ConflictResolveType!
+    $author: AuthorInfo
+  ) {
+    mergeAndResolveConflicts(
+      databaseName: $databaseName
+      fromBranchName: $fromBranchName
+      toBranchName: $toBranchName
+      conflictResolveType: $conflictResolveType
+      author: $author
+    )
+  }
+`;
+
 export const PULL_CONFLICTS_SUMMARY = gql`
   fragment PullConflictSummary on PullConflictSummary {
     _id

--- a/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/useMergeButton.ts
+++ b/web/renderer/components/pageComponents/DatabasePage/ForPulls/PullActions/Merge/useMergeButton.ts
@@ -37,7 +37,7 @@ export default function useMergeButton(params: PullDiffParams) {
   const disabled = hasConflicts;
 
   const onClick = async () => {
-    await merge({
+    const { success } = await merge({
       variables: {
         ...variables,
         author:
@@ -47,13 +47,14 @@ export default function useMergeButton(params: PullDiffParams) {
       },
     });
 
+    if (!success) return;
     res.client
       .refetchQueries(refetchMergeQueriesCacheEvict)
       .catch(console.error);
   };
 
   const onClickWithResolve = async (resolveType: ConflictResolveType) => {
-    await mergeWithResolve({
+    const { success } = await mergeWithResolve({
       variables: {
         ...variables,
         conflictResolveType: resolveType,
@@ -64,6 +65,7 @@ export default function useMergeButton(params: PullDiffParams) {
       },
     });
 
+    if (!success) return;
     res.client
       .refetchQueries(refetchMergeQueriesCacheEvict)
       .catch(console.error);
@@ -80,8 +82,12 @@ export default function useMergeButton(params: PullDiffParams) {
     state,
     setState,
     mergeState: {
-      loading: res.loading || resolveRes.loading,
-      err: res.err ?? resolveRes.err,
+      loading: res.loading,
+      err: res.err,
+    },
+    resolveState: {
+      loading: resolveRes.loading,
+      err: resolveRes.err,
     },
   };
 }

--- a/web/renderer/gen/graphql-types.tsx
+++ b/web/renderer/gen/graphql-types.tsx
@@ -97,6 +97,11 @@ export type CommitList = {
   nextOffset?: Maybe<Scalars['Int']['output']>;
 };
 
+export enum ConflictResolveType {
+  Ours = 'Ours',
+  Theirs = 'Theirs'
+}
+
 export type CurrentDatabaseState = {
   __typename?: 'CurrentDatabaseState';
   currentDatabase?: Maybe<Scalars['String']['output']>;
@@ -250,6 +255,7 @@ export type Mutation = {
   doltClone: Scalars['Boolean']['output'];
   fetchRemote: FetchRes;
   loadDataFile: Scalars['Boolean']['output'];
+  mergeAndResolveConflicts: Scalars['Boolean']['output'];
   mergePull: Scalars['Boolean']['output'];
   pullFromRemote: PullRes;
   pushToRemote: PushRes;
@@ -352,6 +358,15 @@ export type MutationLoadDataFileArgs = {
   refName: Scalars['String']['input'];
   schemaName?: InputMaybe<Scalars['String']['input']>;
   tableName: Scalars['String']['input'];
+};
+
+
+export type MutationMergeAndResolveConflictsArgs = {
+  author?: InputMaybe<AuthorInfo>;
+  conflictResolveType: ConflictResolveType;
+  databaseName: Scalars['String']['input'];
+  fromBranchName: Scalars['String']['input'];
+  toBranchName: Scalars['String']['input'];
 };
 
 
@@ -1336,6 +1351,17 @@ export type MergePullMutationVariables = Exact<{
 
 
 export type MergePullMutation = { __typename?: 'Mutation', mergePull: boolean };
+
+export type MergeAndResolveConflictsMutationVariables = Exact<{
+  databaseName: Scalars['String']['input'];
+  fromBranchName: Scalars['String']['input'];
+  toBranchName: Scalars['String']['input'];
+  conflictResolveType: ConflictResolveType;
+  author?: InputMaybe<AuthorInfo>;
+}>;
+
+
+export type MergeAndResolveConflictsMutation = { __typename?: 'Mutation', mergeAndResolveConflicts: boolean };
 
 export type PullConflictSummaryFragment = { __typename?: 'PullConflictSummary', _id: string, tableName: string, numDataConflicts?: number | null, numSchemaConflicts?: number | null };
 
@@ -3817,6 +3843,47 @@ export function useMergePullMutation(baseOptions?: Apollo.MutationHookOptions<Me
 export type MergePullMutationHookResult = ReturnType<typeof useMergePullMutation>;
 export type MergePullMutationResult = Apollo.MutationResult<MergePullMutation>;
 export type MergePullMutationOptions = Apollo.BaseMutationOptions<MergePullMutation, MergePullMutationVariables>;
+export const MergeAndResolveConflictsDocument = gql`
+    mutation MergeAndResolveConflicts($databaseName: String!, $fromBranchName: String!, $toBranchName: String!, $conflictResolveType: ConflictResolveType!, $author: AuthorInfo) {
+  mergeAndResolveConflicts(
+    databaseName: $databaseName
+    fromBranchName: $fromBranchName
+    toBranchName: $toBranchName
+    conflictResolveType: $conflictResolveType
+    author: $author
+  )
+}
+    `;
+export type MergeAndResolveConflictsMutationFn = Apollo.MutationFunction<MergeAndResolveConflictsMutation, MergeAndResolveConflictsMutationVariables>;
+
+/**
+ * __useMergeAndResolveConflictsMutation__
+ *
+ * To run a mutation, you first call `useMergeAndResolveConflictsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useMergeAndResolveConflictsMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [mergeAndResolveConflictsMutation, { data, loading, error }] = useMergeAndResolveConflictsMutation({
+ *   variables: {
+ *      databaseName: // value for 'databaseName'
+ *      fromBranchName: // value for 'fromBranchName'
+ *      toBranchName: // value for 'toBranchName'
+ *      conflictResolveType: // value for 'conflictResolveType'
+ *      author: // value for 'author'
+ *   },
+ * });
+ */
+export function useMergeAndResolveConflictsMutation(baseOptions?: Apollo.MutationHookOptions<MergeAndResolveConflictsMutation, MergeAndResolveConflictsMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<MergeAndResolveConflictsMutation, MergeAndResolveConflictsMutationVariables>(MergeAndResolveConflictsDocument, options);
+      }
+export type MergeAndResolveConflictsMutationHookResult = ReturnType<typeof useMergeAndResolveConflictsMutation>;
+export type MergeAndResolveConflictsMutationResult = Apollo.MutationResult<MergeAndResolveConflictsMutation>;
+export type MergeAndResolveConflictsMutationOptions = Apollo.BaseMutationOptions<MergeAndResolveConflictsMutation, MergeAndResolveConflictsMutationVariables>;
 export const PullConflictsSummaryDocument = gql`
     query PullConflictsSummary($databaseName: String!, $fromBranchName: String!, $toBranchName: String!) {
   pullConflictsSummary(

--- a/web/renderer/lib/refetchQueries.ts
+++ b/web/renderer/lib/refetchQueries.ts
@@ -145,9 +145,6 @@ export const refetchMergeQueriesCacheEvict: RefetchOptions = {
   updateCache(cache: TCacheShape) {
     [
       "docs",
-      "pullWithDetails",
-      // We don't include `pull` here to avoid multiple pull logs on merge
-      "pulls",
       "doc",
       "rows",
       "tableNames",
@@ -158,6 +155,9 @@ export const refetchMergeQueriesCacheEvict: RefetchOptions = {
       "branchOrDefault",
       "docOrDefaultDoc",
       "pullConflictsSummary",
+      "pullWithDetails",
+      // We don't include `pull` here to avoid multiple pull logs on merge
+      "pulls",
     ].forEach(fieldName => {
       cache.evict({ fieldName });
     });


### PR DESCRIPTION
If a pull request has conflicts (data conflicts only), choose a conflict resolution strategy for all tables (ours or theirs) and successfully merge from the web. More granular conflict resolution from the web coming soon.

<img width="826" height="363" alt="Screenshot 2025-08-20 at 12 29 05 PM" src="https://github.com/user-attachments/assets/9de30643-1560-4c69-809b-6b22579cfaf5" />

<img width="505" height="352" alt="Screenshot 2025-08-20 at 12 29 11 PM" src="https://github.com/user-attachments/assets/b4397099-42b7-4225-98ef-03c4553f5cc3" />
