### PR TITLE
Update build/release versions using PRs during release process

### DIFF
--- a/.github/actions/bump-build-version/action.yaml
+++ b/.github/actions/bump-build-version/action.yaml
@@ -45,18 +45,29 @@ runs:
         echo "New buildVersion in ${{ steps.filepath.outputs.build-config-file }} is ${{ steps.bump-version.outputs.new_version }}"
       shell: bash
 
+    - name: Get current branch
+      id: current-branch
+      run: |
+        echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Add and commit new build version
       if: ${{ inputs.commit == 'true' }}
       uses: EndBug/add-and-commit@v9
       with:
         message: "Update ${{ steps.filepath.outputs.build-config-file }} buildVersion to ${{ steps.bump-version.outputs.new_version }} [skip ci]"
-        new_branch: release/${{ inputs.platform }}-${{ steps.bump-version.outputs.new_version }}
+        pull: ${{ steps.current-branch.outputs.branch != format('build/{0}', inputs.platform) && format('origin {0}', steps.current-branch.outputs.branch) || '' }}
+        push: --set-upstream origin ${{ steps.current-branch.outputs.branch }}
 
     - name: Raise PR and merge
       if: ${{ inputs.commit == 'true' }}
       run: |
-        gh pr create --base main --head release/${{ inputs.platform }}-${{ steps.bump-version.outputs.new_version }} --title "Update ${{ steps.filepath.outputs.build-config-file }} buildVersion to ${{ steps.bump-version.outputs.new_version }}" --body "Increment version"
-        gh pr merge --merge --delete-branch release/${{ inputs.platform }}-${{ steps.bump-version.outputs.new_version }}
+        CURRENT_BRANCH=${{ steps.current-branch.outputs.branch }}
+        if [[ $CURRENT_BRANCH == build/* ]]
+        then
+          gh pr create --base main --head $CURRENT_BRANCH --title "Update ${{ inputs.platform }} build version to ${{ steps.bump-version.outputs.new_version }}" --body "Increment version"
+          gh pr merge --merge --delete-branch $CURRENT_BRANCH
+        fi
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       shell: bash

--- a/.github/actions/bump-build-version/action.yaml
+++ b/.github/actions/bump-build-version/action.yaml
@@ -1,8 +1,11 @@
 name: Bump build version
 description: Bumps SemVer buildVersion in the input builder-config file
 inputs:
-  build-config-file:
-    description: File path to the builder config yaml file
+  platform:
+    description: Platform to update builder config yaml file
+    required: true
+  token:
+    description: GitHub token
     required: true
   commit:
     description: If true, will add and commit the new build version. Default false.
@@ -15,11 +18,17 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Get build config file
+      id: filepath
+      run: |
+        echo "build-config-file=web/build/builder-${{ inputs.platform }}-config.yaml" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Get current build version
       id: current-build-version
       run: |
-        version="$(yq '.buildVersion' ${{ inputs.build-config-file }})"
-        echo "Current buildVersion in ${{ inputs.build-config-file }} is $version"
+        version="$(yq '.buildVersion' ${{ steps.filepath.outputs.build-config-file }})"
+        echo "Current buildVersion in ${{ steps.filepath.outputs.build-config-file }} is $version"
         echo "version=$version" >> $GITHUB_OUTPUT
       shell: bash
 
@@ -30,15 +39,24 @@ runs:
         current_version: ${{ steps.current-build-version.outputs.version }}
         level: patch
 
-    - name: Update ${{ inputs.build-config-file }} buildVersion
+    - name: Update ${{ steps.filepath.outputs.build-config-file }} buildVersion
       run: |
-        yq -i '.buildVersion = "${{ steps.bump-version.outputs.new_version }}"' ${{ inputs.build-config-file }}
-        echo "New buildVersion in ${{ inputs.build-config-file }} is ${{ steps.bump-version.outputs.new_version }}"
+        yq -i '.buildVersion = "${{ steps.bump-version.outputs.new_version }}"' ${{ steps.filepath.outputs.build-config-file }}
+        echo "New buildVersion in ${{ steps.filepath.outputs.build-config-file }} is ${{ steps.bump-version.outputs.new_version }}"
       shell: bash
 
     - name: Add and commit new build version
       if: ${{ inputs.commit == 'true' }}
       uses: EndBug/add-and-commit@v9
       with:
-        message: "Update ${{ inputs.build-config-file }} buildVersion to ${{ steps.bump-version.outputs.new_version }}"
-        pull: origin
+        message: "Update ${{ steps.filepath.outputs.build-config-file }} buildVersion to ${{ steps.bump-version.outputs.new_version }} [skip ci]"
+        new_branch: release/${{ inputs.platform }}-${{ steps.bump-version.outputs.new_version }}
+
+    - name: Raise PR and merge
+      if: ${{ inputs.commit == 'true' }}
+      run: |
+        gh pr create --base main --head release/${{ inputs.platform }}-${{ steps.bump-version.outputs.new_version }} --title "Update ${{ steps.filepath.outputs.build-config-file }} buildVersion to ${{ steps.bump-version.outputs.new_version }}" --body "Increment version"
+        gh pr merge --merge --delete-branch release/${{ inputs.platform }}-${{ steps.bump-version.outputs.new_version }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+      shell: bash

--- a/.github/workflows/cd-release-dmg.yaml
+++ b/.github/workflows/cd-release-dmg.yaml
@@ -25,7 +25,8 @@ jobs:
       - name: Bump build version
         uses: ./.github/actions/bump-build-version
         with:
-          build-config-file: web/build/builder-dmg-config.yaml
+          platform: dmg
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -104,5 +105,6 @@ jobs:
 
       - uses: ./.github/actions/bump-build-version
         with:
-          build-config-file: web/build/builder-dmg-config.yaml
+          platform: dmg
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit: true

--- a/.github/workflows/cd-release-dmg.yaml
+++ b/.github/workflows/cd-release-dmg.yaml
@@ -19,6 +19,12 @@ jobs:
     name: Build Mac release version
     runs-on: macos-14
     steps:
+      - name: Validate branch
+        if: ${{ github.ref_name != 'main' }}
+        run: |
+          echo "This workflow can only run from 'main' (got '${{ github.ref_name }}')." >&2
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v3
 

--- a/.github/workflows/cd-release-dmg.yaml
+++ b/.github/workflows/cd-release-dmg.yaml
@@ -13,6 +13,14 @@ on:
         description: Github Release Version Number
         required: true
         type: string
+      via-call:
+        description: Determines if this workflow was called by another workflow
+        required: false
+        default: true
+        type: boolean
+
+env:
+  VIA_CALL: ${{ inputs.via-call || false }}
 
 jobs:
   build-dmg:
@@ -107,7 +115,23 @@ jobs:
       group: commit-build-version
       cancel-in-progress: false
     steps:
+      - name: Get branch to checkout
+        id: branch-to-update
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ ${{ env.VIA_CALL }} == 'true' ]]; then
+            echo "branch=release/${{ inputs.release-version }}" >> $GITHUB_OUTPUT
+          else
+            echo "branch=build/dmg" >> $GITHUB_OUTPUT
+          fi
+
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout correct branch
+        run: git switch -C ${{ steps.branch-to-update.outputs.branch }}
 
       - uses: ./.github/actions/bump-build-version
         with:

--- a/.github/workflows/cd-release-linux.yaml
+++ b/.github/workflows/cd-release-linux.yaml
@@ -13,6 +13,14 @@ on:
         description: Github Release Version Number
         required: true
         type: string
+      via-call:
+        description: Determines if this workflow was called by another workflow
+        required: false
+        default: true
+        type: boolean
+
+env:
+  VIA_CALL: ${{ inputs.via-call || false }}
 
 jobs:
   build-linux:
@@ -73,7 +81,23 @@ jobs:
       group: commit-build-version
       cancel-in-progress: false
     steps:
+      - name: Get branch to checkout
+        id: branch-to-update
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ ${{ env.VIA_CALL }} == 'true' ]]; then
+            echo "branch=release/${{ inputs.release-version }}" >> $GITHUB_OUTPUT
+          else
+            echo "branch=build/linux" >> $GITHUB_OUTPUT
+          fi
+
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout correct branch
+        run: git switch -C ${{ steps.branch-to-update.outputs.branch }}
 
       - uses: ./.github/actions/bump-build-version
         with:

--- a/.github/workflows/cd-release-linux.yaml
+++ b/.github/workflows/cd-release-linux.yaml
@@ -19,6 +19,12 @@ jobs:
     name: Build Linux release version
     runs-on: ubuntu-22.04
     steps:
+      - name: Validate branch
+        if: ${{ github.ref_name != 'main' }}
+        run: |
+          echo "This workflow can only run from 'main' (got '${{ github.ref_name }}')." >&2
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v3
 

--- a/.github/workflows/cd-release-linux.yaml
+++ b/.github/workflows/cd-release-linux.yaml
@@ -25,7 +25,8 @@ jobs:
       - name: Bump linux build version
         uses: ./.github/actions/bump-build-version
         with:
-          build-config-file: web/build/builder-linux-config.yaml
+          platform: linux
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -70,6 +71,7 @@ jobs:
 
       - uses: ./.github/actions/bump-build-version
         with:
-          build-config-file: web/build/builder-linux-config.yaml
+          platform: linux
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit: true
 

--- a/.github/workflows/cd-release-mas.yaml
+++ b/.github/workflows/cd-release-mas.yaml
@@ -26,7 +26,8 @@ jobs:
         id: bump-mas-version
         uses: ./.github/actions/bump-build-version
         with:
-          build-config-file: web/build/builder-mas-config.yaml
+          platform: mas
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -97,5 +98,6 @@ jobs:
 
       - uses: ./.github/actions/bump-build-version
         with:
-          build-config-file: web/build/builder-mas-config.yaml
+          platform: mas
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit: true

--- a/.github/workflows/cd-release-mas.yaml
+++ b/.github/workflows/cd-release-mas.yaml
@@ -13,6 +13,14 @@ on:
         description: Github Release Version Number
         required: true
         type: string
+      via-call:
+        description: Determines if this workflow was called by another workflow
+        required: false
+        default: true
+        type: boolean
+
+env:
+  VIA_CALL: ${{ inputs.via-call || false }}
 
 jobs:
   build-mas:
@@ -100,7 +108,23 @@ jobs:
       group: commit-build-version
       cancel-in-progress: false
     steps:
+      - name: Get branch to checkout
+        id: branch-to-update
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ ${{ env.VIA_CALL }} == 'true' ]]; then
+            echo "branch=release/${{ inputs.release-version }}" >> $GITHUB_OUTPUT
+          else
+            echo "branch=build/mas" >> $GITHUB_OUTPUT
+          fi
+
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout correct branch
+        run: git switch -C ${{ steps.branch-to-update.outputs.branch }}
 
       - uses: ./.github/actions/bump-build-version
         with:

--- a/.github/workflows/cd-release-mas.yaml
+++ b/.github/workflows/cd-release-mas.yaml
@@ -19,6 +19,12 @@ jobs:
     name: Build Mac App Store release version
     runs-on: macos-14
     steps:
+      - name: Validate branch
+        if: ${{ github.ref_name != 'main' }}
+        run: |
+          echo "This workflow can only run from 'main' (got '${{ github.ref_name }}')." >&2
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v3
 

--- a/.github/workflows/cd-release-windows.yaml
+++ b/.github/workflows/cd-release-windows.yaml
@@ -29,7 +29,8 @@ jobs:
       - name: Bump Windows build version
         uses: ./.github/actions/bump-build-version
         with:
-          build-config-file: web/build/builder-win-config.yaml
+          platform: win
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -82,5 +83,6 @@ jobs:
 
       - uses: ./.github/actions/bump-build-version
         with:
-          build-config-file: web/build/builder-win-config.yaml
+          platform: win
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit: true

--- a/.github/workflows/cd-release-windows.yaml
+++ b/.github/workflows/cd-release-windows.yaml
@@ -19,6 +19,12 @@ jobs:
     name: Build Windows release version
     runs-on: windows-2022
     steps:
+      - name: Validate branch
+        if: ${{ github.ref_name != 'main' }}
+        run: |
+          echo "This workflow can only run from 'main' (got '${{ github.ref_name }}')." >&2
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v3
 

--- a/.github/workflows/cd-release-windows.yaml
+++ b/.github/workflows/cd-release-windows.yaml
@@ -13,6 +13,14 @@ on:
         description: Github Release Version Number
         required: true
         type: string
+      via-call:
+        description: Determines if this workflow was called by another workflow
+        required: false
+        default: true
+        type: boolean
+
+env:
+  VIA_CALL: ${{ inputs.via-call || false }}
 
 jobs:
   build-windows:
@@ -85,7 +93,21 @@ jobs:
       group: commit-build-version
       cancel-in-progress: false
     steps:
+      - name: Get branch to checkout
+        id: branch-to-update
+        run: |
+          if [[ ${{ env.VIA_CALL }} == 'true' ]]; then
+            echo "branch=release/${{ inputs.release-version }}" >> $GITHUB_OUTPUT
+          else
+            echo "branch=build/win" >> $GITHUB_OUTPUT
+          fi
+
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout correct branch
+        run: git switch -C ${{ steps.branch-to-update.outputs.branch }}
 
       - uses: ./.github/actions/bump-build-version
         with:

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -31,6 +31,12 @@ jobs:
       release_id: ${{ steps.create_release.outputs.id }}
       release_version: ${{ needs.format-version.outputs.version }}
     steps:
+      - name: Validate branch
+        if: ${{ github.ref_name != 'main' }}
+        run: |
+          echo "This workflow can only run from 'main' (got '${{ github.ref_name }}')." >&2
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v3
 

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -41,7 +41,15 @@ jobs:
       - name: Add and commit new version
         uses: EndBug/add-and-commit@v9
         with:
-          message: "Update web/package.json version to ${{ needs.format-version.outputs.version }}"
+          message: "Update web/package.json version to ${{ needs.format-version.outputs.version }} [skip ci]"
+          new_branch: release/${{ needs.format-version.outputs.version }}
+
+      - name: Raise PR and merge
+        run: |
+          gh pr create --base main --head release/${{ needs.format-version.outputs.version }} --title "Update web/package.json version to ${{ needs.format-version.outputs.version }}" --body "Increment version"
+          gh pr merge --merge --delete-branch release/${{ needs.format-version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -50,13 +50,6 @@ jobs:
           message: "Update web/package.json version to ${{ needs.format-version.outputs.version }} [skip ci]"
           new_branch: release/${{ needs.format-version.outputs.version }}
 
-      - name: Raise PR and merge
-        run: |
-          gh pr create --base main --head release/${{ needs.format-version.outputs.version }} --title "Update web/package.json version to ${{ needs.format-version.outputs.version }}" --body "Increment version"
-          gh pr merge --merge --delete-branch release/${{ needs.format-version.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Create Release
         id: create_release
         uses: dolthub/create-release@v1
@@ -118,4 +111,21 @@ jobs:
     secrets: inherit
     with:
       release-version: ${{ needs.create-release.outputs.release_version }}
+
+  create-pr-and-merge:
+    name: Create PR and merge
+    needs: [create-release, build-mas, build-windows, build-dmg, build-linux]
+    if: ${{ always() && needs.create-release.result == 'success' && !cancelled() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Create PR and merge
+        run: |
+          gh pr create --base main --head release/${{ needs.create-release.outputs.release_version }} --title "Update versions for release ${{ needs.create-release.outputs.release_version }}" --body "Increment versions"
+          gh pr merge --merge --delete-branch release/${{ needs.create-release.outputs.release_version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
 


### PR DESCRIPTION
This will 1) raise a PR and merge instead of trying to force push directly to main for the version updates and 2) block any attempted workflow runs from non-main branches