### PR TITLE
fix cache invalidation and refresh button inconsistencies

### DIFF
--- a/web/renderer/components/DatabaseHeaderAndNav/RefreshConnectionButton.tsx
+++ b/web/renderer/components/DatabaseHeaderAndNav/RefreshConnectionButton.tsx
@@ -10,16 +10,19 @@ import useMutation from "@hooks/useMutation";
 import { IoReloadSharp } from "@react-icons/all-files/io5/IoReloadSharp";
 import { useState } from "react";
 import css from "./index.module.css";
+import { useRouter } from "next/router";
 
 export default function ResetConnectionButton() {
   const { mutateFn, loading, err, setErr, client } = useMutation({
     hook: useResetDatabaseMutation,
   });
+  const router = useRouter();
   const [errorModalOpen, setErrorModalOpen] = useState(false);
 
   const onClick = async () => {
     await mutateFn();
     await client.resetStore();
+    router.reload();
   };
 
   const onClose = () => {

--- a/web/renderer/components/pageComponents/DatabasePage/ForTable/index.tsx
+++ b/web/renderer/components/pageComponents/DatabasePage/ForTable/index.tsx
@@ -12,6 +12,9 @@ type Props = {
 };
 
 export default function ForTable(props: Props) {
+  if (!props.params.tableName) {
+    return null;
+  }
   const { schemaName, tableName } = getSchemaAndTableName(props.params);
   const params = { ...props.params, schemaName, tableName };
   return (

--- a/web/renderer/lib/apollo.tsx
+++ b/web/renderer/lib/apollo.tsx
@@ -34,6 +34,11 @@ export function createApolloClient(
       uri,
       headers,
     }),
+    defaultOptions: {
+      watchQuery: {
+        fetchPolicy: "cache-and-network",
+      },
+    },
   });
 }
 


### PR DESCRIPTION
This fix will make it so the 'cache-and-network' fetch policy is applied by default to all requests. Also, updates the refresh button so it actually does a page reload instead of just refreshing the connection. 