### PR TITLE
Fix styling on enum dropdown

### DIFF
--- a/web/renderer/components/EditCellInput/Input.tsx
+++ b/web/renderer/components/EditCellInput/Input.tsx
@@ -49,11 +49,39 @@ export default function Input(props: Props) {
         outerClassName={css.editSelect}
         mono
         small
+        isSearchable
+        menuPortalTarget={document.body}
         customStyles={s => {
           return {
             ...s,
+            control: styles => {
+              return {
+                ...styles,
+                minWidth: "100px",
+                width: "100%",
+              };
+            },
+            menu: styles => {
+              return {
+                ...styles,
+                width: "max-content",
+                minWidth: "100%",
+              };
+            },
             singleValue: styles => {
-              return { ...styles, marginBottom: "6px" };
+              return {
+                ...styles,
+                marginBottom: "6px",
+                overflow: "visible",
+                textOverflow: "clip",
+                whiteSpace: "nowrap",
+              };
+            },
+            option: styles => {
+              return {
+                ...styles,
+                whiteSpace: "nowrap",
+              };
             },
           };
         }}

--- a/web/renderer/components/EditCellInput/Input.tsx
+++ b/web/renderer/components/EditCellInput/Input.tsx
@@ -66,6 +66,7 @@ export default function Input(props: Props) {
                 ...styles,
                 width: "max-content",
                 minWidth: "100%",
+                maxWidth: "300px",
               };
             },
             singleValue: styles => {
@@ -80,7 +81,8 @@ export default function Input(props: Props) {
             option: styles => {
               return {
                 ...styles,
-                whiteSpace: "nowrap",
+                whiteSpace: "normal",
+                wordWrap: "break-word",
               };
             },
           };


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt-workbench/issues/622.

Now it's a scrollable dropdown and you can also type into the box to filter down the options:
<img width="1085" height="532" alt="Screenshot 2025-09-15 at 2 02 43 PM" src="https://github.com/user-attachments/assets/fea18f36-a688-43ca-9b8c-dc247fc25fd0" />
