### PR TITLE
Add row highlighting for working changes

### DIFF
--- a/graphql-server/schema.gql
+++ b/graphql-server/schema.gql
@@ -160,22 +160,12 @@ type ColumnValue {
 
 type Row {
   columnValues: [ColumnValue!]!
+  diffType: String
 }
 
 type RowList {
   nextOffset: Int
   list: [Row!]!
-}
-
-type RowWithDiff {
-  index: Int!
-  diffType: String!
-}
-
-type RowWithDiffList {
-  nextOffset: Int
-  list: [Row!]!
-  diffs: [RowWithDiff!]
 }
 
 type Doc {
@@ -407,8 +397,7 @@ type Query {
   remotes(databaseName: String!, offset: Int): RemoteList!
   remoteBranchDiffCounts(databaseName: String!, fromRefName: String!, toRefName: String!): RemoteBranchDiffCounts!
   rowDiffs(offset: Int, databaseName: String!, fromRefName: String!, toRefName: String!, refName: String, tableName: String!, filterByRowType: DiffRowType, type: CommitDiffType): RowDiffList!
-  rows(schemaName: String, refName: String!, databaseName: String!, tableName: String!, offset: Int): RowList!
-  rowsWithWorkingDiff(schemaName: String, refName: String!, databaseName: String!, tableName: String!, offset: Int): RowWithDiffList!
+  rows(schemaName: String, refName: String!, databaseName: String!, tableName: String!, offset: Int, withDiff: Boolean): RowList!
   schemaDiff(databaseName: String!, fromRefName: String!, toRefName: String!, refName: String, tableName: String!, type: CommitDiffType): SchemaDiff
   doltSchemas(refName: String!, databaseName: String!, schemaName: String): [SchemaItem!]!
   views(refName: String!, databaseName: String!, schemaName: String): [SchemaItem!]!

--- a/graphql-server/schema.gql
+++ b/graphql-server/schema.gql
@@ -167,6 +167,17 @@ type RowList {
   list: [Row!]!
 }
 
+type RowWithDiff {
+  index: Int!
+  diffType: String!
+}
+
+type RowWithDiffList {
+  nextOffset: Int
+  list: [Row!]!
+  diffs: [RowWithDiff!]
+}
+
 type Doc {
   docType: String!
   docRow: Row
@@ -397,6 +408,7 @@ type Query {
   remoteBranchDiffCounts(databaseName: String!, fromRefName: String!, toRefName: String!): RemoteBranchDiffCounts!
   rowDiffs(offset: Int, databaseName: String!, fromRefName: String!, toRefName: String!, refName: String, tableName: String!, filterByRowType: DiffRowType, type: CommitDiffType): RowDiffList!
   rows(schemaName: String, refName: String!, databaseName: String!, tableName: String!, offset: Int): RowList!
+  rowsWithWorkingDiff(schemaName: String, refName: String!, databaseName: String!, tableName: String!, offset: Int): RowWithDiffList!
   schemaDiff(databaseName: String!, fromRefName: String!, toRefName: String!, refName: String, tableName: String!, type: CommitDiffType): SchemaDiff
   doltSchemas(refName: String!, databaseName: String!, schemaName: String): [SchemaItem!]!
   views(refName: String!, databaseName: String!, schemaName: String): [SchemaItem!]!

--- a/graphql-server/src/queryFactory/dolt/doltEntityManager.ts
+++ b/graphql-server/src/queryFactory/dolt/doltEntityManager.ts
@@ -6,7 +6,7 @@ import { ROW_LIMIT, handleTableNotFound } from "../../utils";
 import { tableWithSchema } from "../postgres/utils";
 import * as t from "../types";
 import { getOrderByColForBranches } from "./queries";
-import { PR, TableRowPagination, TestArgs } from "../types";
+import { TableRowPagination, TestArgs } from "../types";
 
 export async function getDoltSchemas(
   em: EntityManager,
@@ -59,24 +59,23 @@ export async function getTableRowsWithDiff(
   tableName: string,
   page: TableRowPagination,
 ): t.PR {
+  const joinOnPks = page.pkCols.map(pk => `t.${pk} = d.to_${pk}`).join(" AND ");
 
-  const joinOnPks = page.pkCols
-    .map(pk => `t.${pk} = d.to_${pk}`)
-    .join(" AND ");
-
-  const onClause = `${joinOnPks} AND d.to_commit = :commit`;
+  const joinOnCommit = "d.to_commit = :commit";
+  const onClause = joinOnPks
+    ? `${joinOnPks} AND ${joinOnCommit}`
+    : joinOnCommit;
 
   const sel = em
     .createQueryBuilder()
     .select(`t.*`)
     .addSelect("d.diff_type")
     .from(tableName, "t")
-    .leftJoin(`dolt_diff_${tableName}`, "d", onClause, { commit: "WORKING" })
+    .leftJoin(`dolt_diff_${tableName}`, "d", onClause, { commit: "WORKING" });
 
   page.pkCols.forEach(pk => {
-    sel.addOrderBy(`t.${pk}`, "ASC")
+    sel.addOrderBy(`t.${pk}`, "ASC");
   });
-  console.log(sel.getSql());
 
   return sel
     .limit(ROW_LIMIT + 1)

--- a/graphql-server/src/queryFactory/dolt/index.ts
+++ b/graphql-server/src/queryFactory/dolt/index.ts
@@ -87,7 +87,7 @@ export class DoltQueryFactory
 
   async getTablePKColumns(args: t.TableArgs): Promise<string[]> {
     const res: t.RawRows = await this.query(
-      qh.tableColsQuery,
+      qh.columnsQuery,
       [args.tableName],
       args.databaseName,
       args.refName,
@@ -109,6 +109,15 @@ export class DoltQueryFactory
       args.databaseName,
       args.refName,
     );
+  }
+
+  async getTableRowsWithDiff(args: t.TableMaybeSchemaArgs, page: t.TableRowPagination): t.PR {
+    return this.queryForBuilder(
+      async em => dem.getTableRowsWithDiff(em, args.tableName, page),
+      args.databaseName,
+      args.refName,
+    )
+
   }
 
   async getBranch(args: t.BranchArgs): t.USPR {

--- a/graphql-server/src/queryFactory/dolt/index.ts
+++ b/graphql-server/src/queryFactory/dolt/index.ts
@@ -111,13 +111,15 @@ export class DoltQueryFactory
     );
   }
 
-  async getTableRowsWithDiff(args: t.TableMaybeSchemaArgs, page: t.TableRowPagination): t.PR {
+  async getTableRowsWithDiff(
+    args: t.TableMaybeSchemaArgs,
+    page: t.TableRowPagination,
+  ): t.PR {
     return this.queryForBuilder(
       async em => dem.getTableRowsWithDiff(em, args.tableName, page),
       args.databaseName,
       args.refName,
-    )
-
+    );
   }
 
   async getBranch(args: t.BranchArgs): t.USPR {

--- a/graphql-server/src/queryFactory/doltgres/index.ts
+++ b/graphql-server/src/queryFactory/doltgres/index.ts
@@ -128,6 +128,17 @@ export class DoltgresQueryFactory
     );
   }
 
+  async getTableRowsWithDiff(
+    args: t.TableMaybeSchemaArgs,
+    page: t.TableRowPagination,
+  ): t.PR {
+    return this.queryForBuilder(
+      async em => dem.getTableRowsWithDiff(em, args.tableName, page),
+      args.databaseName,
+      args.refName,
+    );
+  }
+
   async getBranch(args: t.BranchArgs): t.USPR {
     return this.queryForBuilder(
       async em => dem.getDoltBranch(em, args),

--- a/graphql-server/src/queryFactory/index.ts
+++ b/graphql-server/src/queryFactory/index.ts
@@ -70,7 +70,6 @@ export declare class QueryFactory {
 
   getTableRows(args: t.TableMaybeSchemaArgs, page: t.TableRowPagination): t.PR;
 
-
   getSqlSelect(
     args: t.RefMaybeSchemaArgs & { queryString: string },
   ): Promise<{ rows: t.RawRows; warnings?: string[] }>;
@@ -83,7 +82,10 @@ export declare class QueryFactory {
   getProcedures(args: t.RefArgs): Promise<SchemaItem[]>;
 
   // DOLT-SPECIFIC QUERIES
-  getTableRowsWithDiff(args: t.TableMaybeSchemaArgs, page: t.TableRowPagination): t.PR;
+  getTableRowsWithDiff(
+    args: t.TableMaybeSchemaArgs,
+    page: t.TableRowPagination,
+  ): t.PR;
 
   getBranch(args: t.BranchArgs): t.USPR;
 

--- a/graphql-server/src/queryFactory/index.ts
+++ b/graphql-server/src/queryFactory/index.ts
@@ -70,6 +70,7 @@ export declare class QueryFactory {
 
   getTableRows(args: t.TableMaybeSchemaArgs, page: t.TableRowPagination): t.PR;
 
+
   getSqlSelect(
     args: t.RefMaybeSchemaArgs & { queryString: string },
   ): Promise<{ rows: t.RawRows; warnings?: string[] }>;
@@ -82,6 +83,7 @@ export declare class QueryFactory {
   getProcedures(args: t.RefArgs): Promise<SchemaItem[]>;
 
   // DOLT-SPECIFIC QUERIES
+  getTableRowsWithDiff(args: t.TableMaybeSchemaArgs, page: t.TableRowPagination): t.PR;
 
   getBranch(args: t.BranchArgs): t.USPR;
 

--- a/graphql-server/src/queryFactory/mysql/index.ts
+++ b/graphql-server/src/queryFactory/mysql/index.ts
@@ -195,7 +195,10 @@ export class MySQLQueryFactory
 
   // DOLT QUERIES NOT IMPLEMENTED FOR MYSQL
 
-  async getTableRowsWithDiff(_args: t.TableArgs, _page: t.TableRowPagination): t.PR {
+  async getTableRowsWithDiff(
+    _args: t.TableArgs,
+    _page: t.TableRowPagination,
+  ): t.PR {
     throw notDoltError("get table rows with diff");
   }
 

--- a/graphql-server/src/queryFactory/mysql/index.ts
+++ b/graphql-server/src/queryFactory/mysql/index.ts
@@ -195,6 +195,10 @@ export class MySQLQueryFactory
 
   // DOLT QUERIES NOT IMPLEMENTED FOR MYSQL
 
+  async getTableRowsWithDiff(_args: t.TableArgs, _page: t.TableRowPagination): t.PR {
+    throw notDoltError("get table rows with diff");
+  }
+
   // Returns static branch
   async getBranch(args: t.BranchArgs): t.USPR {
     return {

--- a/graphql-server/src/rows/row.model.ts
+++ b/graphql-server/src/rows/row.model.ts
@@ -1,5 +1,5 @@
 import { getUTCDateAndTimeString } from "@dolthub/web-utils";
-import {Field, Int, ObjectType} from "@nestjs/graphql";
+import { Field, ObjectType } from "@nestjs/graphql";
 import { RawRow } from "../queryFactory/types";
 import { ROW_LIMIT, getNextOffset } from "../utils";
 import { ListOffsetRes } from "../utils/commonTypes";
@@ -18,27 +18,15 @@ export class ColumnValue {
 export class Row {
   @Field(_type => [ColumnValue])
   columnValues: ColumnValue[];
+
+  @Field({ nullable: true })
+  diffType?: string;
 }
 
 @ObjectType()
 export class RowList extends ListOffsetRes {
   @Field(_type => [Row])
   list: Row[];
-}
-
-@ObjectType()
-export class RowWithDiff {
-    @Field(_type => Int)
-    index: number;
-
-    @Field()
-    diffType: string;
-}
-
-@ObjectType()
-export class RowWithDiffList extends RowList {
-    @Field(_type => [RowWithDiff], { nullable: true })
-    diffs: RowWithDiff[] | undefined;
 }
 
 export function fromDoltListRowRes(rows: RawRow[], offset: number): RowList {
@@ -48,13 +36,14 @@ export function fromDoltListRowRes(rows: RawRow[], offset: number): RowList {
   };
 }
 
-export function fromDoltListRowWithDiffRes(rows: RawRow[], offset: number): RowWithDiffList {
-
-    return {
-        list: rows.slice(0, ROW_LIMIT).map(fromDoltRowWithDiffRes),
-        diffs: fromDoltDiffRes(rows.slice(0, ROW_LIMIT)),
-        nextOffset: getNextOffset(rows.length, offset),
-    };
+export function fromDoltListRowWithDiffRes(
+  rows: RawRow[],
+  offset: number,
+): RowList {
+  return {
+    list: rows.slice(0, ROW_LIMIT).map(fromDoltRowWithDiffRes),
+    nextOffset: getNextOffset(rows.length, offset),
+  };
 }
 
 export function getCellValue(value: any, colName?: string): string {
@@ -92,23 +81,13 @@ export function fromDoltRowRes(row: RawRow): Row {
 }
 
 export function fromDoltRowWithDiffRes(row: RawRow): Row {
-    const columnValues = Object.entries(row);
-    return {
-        columnValues: columnValues.slice(0, columnValues.length - 1).map(([key, cell]) => {
-            return { displayValue: getCellValue(cell, key) };
-        })
-    }
-}
-
-export function fromDoltDiffRes(rows: RawRow[]) {
-    let diffs: RowWithDiff[] = [];
-    for (let i = 0; i < rows.length; i++) {
-        if (rows[i].diff_type && (rows[i].diff_type === "modified" || rows[i].diff_type === "added")) {
-            diffs.push({
-                index: i,
-                diffType: rows[i].diff_type,
-            })
-        }
-    }
-    return diffs;
+  const columnValues = Object.entries(row);
+  return {
+    columnValues: columnValues
+      .slice(0, columnValues.length - 1)
+      .map(([key, cell]) => {
+        return { displayValue: getCellValue(cell, key) };
+      }),
+    diffType: row.diff_type,
+  };
 }

--- a/graphql-server/src/rows/row.resolver.ts
+++ b/graphql-server/src/rows/row.resolver.ts
@@ -1,7 +1,13 @@
 import { Args, ArgsType, Field, Int, Query, Resolver } from "@nestjs/graphql";
 import { ConnectionProvider } from "../connections/connection.provider";
 import { RefMaybeSchemaArgs } from "../utils/commonTypes";
-import { Row, RowList, fromDoltListRowRes } from "./row.model";
+import {
+    Row,
+    RowList,
+    fromDoltListRowRes,
+    fromDoltListRowWithDiffRes,
+    RowWithDiffList
+} from "./row.model";
 
 @ArgsType()
 export class ListRowsArgs extends RefMaybeSchemaArgs {
@@ -21,10 +27,17 @@ export class RowResolver {
     const conn = this.conn.connection();
     const pkCols = await conn.getTablePKColumns(args);
     const offset = args.offset ?? 0;
-    const rows = await conn.getTableRows(args, {
-      pkCols,
-      offset,
-    });
+    const rows = await conn.getTableRows(args, { pkCols, offset });
     return fromDoltListRowRes(rows, offset);
   }
+
+  @Query(_returns => RowWithDiffList)
+  async rowsWithWorkingDiff(@Args() args: ListRowsArgs): Promise<RowWithDiffList> {
+    const conn = this.conn.connection();
+    const pkCols = await conn.getTablePKColumns(args);
+    const offset = args.offset ?? 0;
+    const rowsWithDiff = await conn.getTableRowsWithDiff(args, { pkCols, offset });
+    return fromDoltListRowWithDiffRes(rowsWithDiff, offset);
+  }
+
 }

--- a/web/renderer/components/DataTable/Table/Body.tsx
+++ b/web/renderer/components/DataTable/Table/Body.tsx
@@ -20,7 +20,7 @@ type Props = {
 };
 
 export default function Body(props: Props) {
-  const { columns, pendingRow, diffs } = useDataTableContext();
+  const { columns, pendingRow } = useDataTableContext();
   const showRowDropdown =
     !isKeyless(columns) && queryShowingPKs(props.columns, columns);
   const cols = getTableColsFromQueryCols(props.columns, columns);
@@ -40,7 +40,6 @@ export default function Body(props: Props) {
           row={r}
           ridx={ridx}
           showRowDropdown={showRowDropdown}
-          workingDiffType={diffs?.find(diff => diff.index === ridx)?.diffType}
         />
       ))}
     </tbody>

--- a/web/renderer/components/DataTable/Table/Body.tsx
+++ b/web/renderer/components/DataTable/Table/Body.tsx
@@ -20,7 +20,7 @@ type Props = {
 };
 
 export default function Body(props: Props) {
-  const { columns, pendingRow } = useDataTableContext();
+  const { columns, pendingRow, diffs } = useDataTableContext();
   const showRowDropdown =
     !isKeyless(columns) && queryShowingPKs(props.columns, columns);
   const cols = getTableColsFromQueryCols(props.columns, columns);
@@ -40,6 +40,7 @@ export default function Body(props: Props) {
           row={r}
           ridx={ridx}
           showRowDropdown={showRowDropdown}
+          workingDiffType={diffs?.find(diff => diff.index === ridx)?.diffType}
         />
       ))}
     </tbody>

--- a/web/renderer/components/DataTable/Table/Row.tsx
+++ b/web/renderer/components/DataTable/Table/Row.tsx
@@ -7,11 +7,10 @@ import {
   RowForDataTableFragment,
 } from "@gen/graphql-types";
 import { ColumnStatus } from "@lib/tableTypes";
-import cx from "classnames";
 import { useState } from "react";
 import Cell from "./Cell";
 import css from "./index.module.css";
-import { getDiffTypeClassnameForRow } from "./utils";
+import { getDiffTypeClassNameForRow } from "./utils";
 
 type Props = {
   row: RowForDataTableFragment;
@@ -20,17 +19,19 @@ type Props = {
   showRowDropdown: boolean;
   isMobile?: boolean;
   columnStatus: ColumnStatus;
+  workingDiffType?: string | undefined;
 };
 
 export default function Row(props: Props) {
   const [showDropdown, setShowDropdown] = useState(false);
-  const diffTypeClassname = getDiffTypeClassnameForRow(
+  const diffTypeClassName = getDiffTypeClassNameForRow(
     props.row,
     props.columns,
+    props.workingDiffType,
   );
 
   return (
-    <tr className={cx(css.row, diffTypeClassname)}>
+    <tr className={diffTypeClassName}>
       <td>
         {props.showRowDropdown && (
           <CellDropdown

--- a/web/renderer/components/DataTable/Table/Row.tsx
+++ b/web/renderer/components/DataTable/Table/Row.tsx
@@ -47,11 +47,7 @@ export default function Row(props: Props) {
       </td>
       {props.row.columnValues.map((c, cidx) => (
         // eslint-disable-next-line react/jsx-key
-        <Cell
-          {...props}
-          cell={c}
-          cidx={cidx}
-        />
+        <Cell {...props} cell={c} cidx={cidx} />
       ))}
     </tr>
   );

--- a/web/renderer/components/DataTable/Table/Row.tsx
+++ b/web/renderer/components/DataTable/Table/Row.tsx
@@ -27,7 +27,6 @@ export default function Row(props: Props) {
   const diffTypeClassName = getDiffTypeClassNameForRow(
     props.row,
     props.columns,
-    props.workingDiffType,
   );
 
   return (
@@ -48,7 +47,11 @@ export default function Row(props: Props) {
       </td>
       {props.row.columnValues.map((c, cidx) => (
         // eslint-disable-next-line react/jsx-key
-        <Cell {...props} cell={c} cidx={cidx} />
+        <Cell
+          {...props}
+          cell={c}
+          cidx={cidx}
+        />
       ))}
     </tr>
   );

--- a/web/renderer/components/DataTable/Table/index.module.css
+++ b/web/renderer/components/DataTable/Table/index.module.css
@@ -96,6 +96,10 @@
   @apply bg-green-50;
 }
 
+.modifiedRow {
+    @apply bg-yellow-100;
+}
+
 .removedRow {
   @apply bg-red-50/70;
 }
@@ -163,6 +167,15 @@
 .row:hover .rowDropdown {
   @apply visible;
 }
+
+.rowAdded {
+    @apply bg-green-100;
+}
+
+.rowModified {
+    @apply bg-yellow-100;
+}
+
 
 .tableDropdown {
   @apply relative;

--- a/web/renderer/components/DataTable/Table/index.module.css
+++ b/web/renderer/components/DataTable/Table/index.module.css
@@ -74,6 +74,12 @@
   .pendingRow:hover {
     @apply bg-white;
   }
+  tr.workingDiffRowAdded:hover {
+    @apply bg-green-100;
+  }
+  tr.workingDiffRowModified:hover {
+    @apply bg-yellow-100;
+  }
 }
 
 .tableWithDiff {
@@ -94,10 +100,6 @@
 
 .addedRow {
   @apply bg-green-50;
-}
-
-.modifiedRow {
-  @apply bg-yellow-100;
 }
 
 .removedRow {
@@ -168,11 +170,11 @@
   @apply visible;
 }
 
-.rowAdded {
+.workingDiffRowAdded {
   @apply bg-green-100;
 }
 
-.rowModified {
+.workingDiffRowModified {
   @apply bg-yellow-100;
 }
 

--- a/web/renderer/components/DataTable/Table/index.module.css
+++ b/web/renderer/components/DataTable/Table/index.module.css
@@ -97,7 +97,7 @@
 }
 
 .modifiedRow {
-    @apply bg-yellow-100;
+  @apply bg-yellow-100;
 }
 
 .removedRow {
@@ -169,13 +169,12 @@
 }
 
 .rowAdded {
-    @apply bg-green-100;
+  @apply bg-green-100;
 }
 
 .rowModified {
-    @apply bg-yellow-100;
+  @apply bg-yellow-100;
 }
-
 
 .tableDropdown {
   @apply relative;

--- a/web/renderer/components/DataTable/Table/utils.test.tsx
+++ b/web/renderer/components/DataTable/Table/utils.test.tsx
@@ -7,7 +7,7 @@ import cx from "classnames";
 import css from "./index.module.css";
 import {
   getDiffTypeClassnameForCell,
-  getDiffTypeClassnameForRow,
+  getDiffTypeClassNameForDiffTableRow,
   getDiffTypeColumnIndex,
 } from "./utils";
 
@@ -74,7 +74,7 @@ describe("tests getDiffTypeClassnameForRow", () => {
 
   tests.forEach(test => {
     it(`tests getDiffTypeClassnameForRow for ${test.desc}`, () => {
-      expect(getDiffTypeClassnameForRow(test.row, test.cols)).toEqual(
+      expect(getDiffTypeClassNameForDiffTableRow(test.row, test.cols)).toEqual(
         test.expectedClassName,
       );
     });

--- a/web/renderer/components/DataTable/Table/utils.ts
+++ b/web/renderer/components/DataTable/Table/utils.ts
@@ -22,16 +22,15 @@ export function getDiffTypeClassNameForDiffTableRow(
 }
 
 export function getDiffTypeClassNameForRow(
-    row: RowForDataTableFragment,
-    cols: ColumnForDataTableFragment[],
-    workingDiffType?: string | undefined,
+  row: RowForDataTableFragment,
+  cols: ColumnForDataTableFragment[],
 ): string {
-    const classNameForDiffTable = getDiffTypeClassNameForDiffTableRow(row, cols);
-    return cx(css.row, {
-        [classNameForDiffTable]: !!classNameForDiffTable,
-        [css.rowAdded]: !classNameForDiffTable && workingDiffType === "added",
-        [css.rowModified]: !classNameForDiffTable && workingDiffType === "modified",
-    })
+  const classNameForDiffTable = getDiffTypeClassNameForDiffTableRow(row, cols);
+  return cx(css.row, {
+    [classNameForDiffTable]: !!classNameForDiffTable,
+    [css.rowAdded]: !classNameForDiffTable && row.diffType === "added",
+    [css.rowModified]: !classNameForDiffTable && row.diffType === "modified",
+  });
 }
 
 const diffTableMetaColumns = [
@@ -41,7 +40,6 @@ const diffTableMetaColumns = [
   "to_commit_date",
   "diff_type",
 ];
-
 
 // Returns deleted or added className for cell in modified row in
 // dolt_(commit_)diff_$TABLENAME

--- a/web/renderer/components/DataTable/Table/utils.ts
+++ b/web/renderer/components/DataTable/Table/utils.ts
@@ -28,8 +28,8 @@ export function getDiffTypeClassNameForRow(
   const classNameForDiffTable = getDiffTypeClassNameForDiffTableRow(row, cols);
   return cx(css.row, {
     [classNameForDiffTable]: !!classNameForDiffTable,
-    [css.rowAdded]: !classNameForDiffTable && row.diffType === "added",
-    [css.rowModified]: !classNameForDiffTable && row.diffType === "modified",
+    [css.workingDiffRowAdded]: !classNameForDiffTable && row.diffType === "added",
+    [css.workingDiffRowModified]: !classNameForDiffTable && row.diffType === "modified",
   });
 }
 

--- a/web/renderer/components/DataTable/Table/utils.ts
+++ b/web/renderer/components/DataTable/Table/utils.ts
@@ -7,7 +7,7 @@ import cx from "classnames";
 import css from "./index.module.css";
 
 // Returns removed or added className for row in dolt_(commit_)diff_$TABLENAME
-export function getDiffTypeClassnameForRow(
+export function getDiffTypeClassNameForDiffTableRow(
   row: RowForDataTableFragment,
   cols: ColumnForDataTableFragment[],
 ): string {
@@ -21,6 +21,19 @@ export function getDiffTypeClassnameForRow(
   return cx([css[colVal]], [css[`${colVal}Row`]]);
 }
 
+export function getDiffTypeClassNameForRow(
+    row: RowForDataTableFragment,
+    cols: ColumnForDataTableFragment[],
+    workingDiffType?: string | undefined,
+): string {
+    const classNameForDiffTable = getDiffTypeClassNameForDiffTableRow(row, cols);
+    return cx(css.row, {
+        [classNameForDiffTable]: !!classNameForDiffTable,
+        [css.rowAdded]: !classNameForDiffTable && workingDiffType === "added",
+        [css.rowModified]: !classNameForDiffTable && workingDiffType === "modified",
+    })
+}
+
 const diffTableMetaColumns = [
   "from_commit",
   "to_commit",
@@ -28,6 +41,7 @@ const diffTableMetaColumns = [
   "to_commit_date",
   "diff_type",
 ];
+
 
 // Returns deleted or added className for cell in modified row in
 // dolt_(commit_)diff_$TABLENAME

--- a/web/renderer/contexts/dataTable/queries.ts
+++ b/web/renderer/contexts/dataTable/queries.ts
@@ -75,3 +75,38 @@ export const ROWS_FOR_DATA_TABLE = gql`
     }
   }
 `;
+
+export const ROWS_WITH_DIFF_FOR_DATA_TABLE = gql`
+  fragment RowForDataTable on Row {
+    columnValues {
+      displayValue
+    }
+  }
+  fragment RowWithDiffListRows on RowWithDiffList {
+    nextOffset
+    list {
+      ...RowForDataTable
+    }
+    diffs {
+      index
+      diffType
+    }
+  }
+  query RowsWithDiffForDataTableQuery(
+    $databaseName: String!
+    $refName: String!
+    $tableName: String!
+    $schemaName: String
+    $offset: Int
+  ) {
+    rowsWithWorkingDiff(
+      databaseName: $databaseName
+      refName: $refName
+      tableName: $tableName
+      schemaName: $schemaName
+      offset: $offset
+    ) {
+      ...RowWithDiffListRows
+    }
+  }
+`;

--- a/web/renderer/contexts/dataTable/queries.ts
+++ b/web/renderer/contexts/dataTable/queries.ts
@@ -50,6 +50,7 @@ export const ROWS_FOR_DATA_TABLE = gql`
     columnValues {
       displayValue
     }
+    diffType
   }
   fragment RowListRows on RowList {
     nextOffset
@@ -63,6 +64,7 @@ export const ROWS_FOR_DATA_TABLE = gql`
     $tableName: String!
     $schemaName: String
     $offset: Int
+    $withDiff: Boolean
   ) {
     rows(
       databaseName: $databaseName
@@ -70,43 +72,9 @@ export const ROWS_FOR_DATA_TABLE = gql`
       tableName: $tableName
       schemaName: $schemaName
       offset: $offset
+      withDiff: $withDiff
     ) {
       ...RowListRows
-    }
-  }
-`;
-
-export const ROWS_WITH_DIFF_FOR_DATA_TABLE = gql`
-  fragment RowForDataTable on Row {
-    columnValues {
-      displayValue
-    }
-  }
-  fragment RowWithDiffListRows on RowWithDiffList {
-    nextOffset
-    list {
-      ...RowForDataTable
-    }
-    diffs {
-      index
-      diffType
-    }
-  }
-  query RowsWithDiffForDataTableQuery(
-    $databaseName: String!
-    $refName: String!
-    $tableName: String!
-    $schemaName: String
-    $offset: Int
-  ) {
-    rowsWithWorkingDiff(
-      databaseName: $databaseName
-      refName: $refName
-      tableName: $tableName
-      schemaName: $schemaName
-      offset: $offset
-    ) {
-      ...RowWithDiffListRows
     }
   }
 `;

--- a/web/renderer/gen/graphql-types.tsx
+++ b/web/renderer/gen/graphql-types.tsx
@@ -502,6 +502,7 @@ export type Query = {
   remotes: RemoteList;
   rowDiffs: RowDiffList;
   rows: RowList;
+  rowsWithWorkingDiff: RowWithDiffList;
   runTests: TestResultList;
   schemaDiff?: Maybe<SchemaDiff>;
   schemas: Array<Scalars['String']['output']>;
@@ -692,6 +693,15 @@ export type QueryRowsArgs = {
 };
 
 
+export type QueryRowsWithWorkingDiffArgs = {
+  databaseName: Scalars['String']['input'];
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  refName: Scalars['String']['input'];
+  schemaName?: InputMaybe<Scalars['String']['input']>;
+  tableName: Scalars['String']['input'];
+};
+
+
 export type QueryRunTestsArgs = {
   databaseName: Scalars['String']['input'];
   refName: Scalars['String']['input'];
@@ -846,6 +856,19 @@ export type RowDiffList = {
 
 export type RowList = {
   __typename?: 'RowList';
+  list: Array<Row>;
+  nextOffset?: Maybe<Scalars['Int']['output']>;
+};
+
+export type RowWithDiff = {
+  __typename?: 'RowWithDiff';
+  diffType: Scalars['String']['output'];
+  index: Scalars['Int']['output'];
+};
+
+export type RowWithDiffList = {
+  __typename?: 'RowWithDiffList';
+  diffs?: Maybe<Array<RowWithDiff>>;
   list: Array<Row>;
   nextOffset?: Maybe<Scalars['Int']['output']>;
 };
@@ -1661,6 +1684,19 @@ export type RowsForDataTableQueryVariables = Exact<{
 
 export type RowsForDataTableQuery = { __typename?: 'Query', rows: { __typename?: 'RowList', nextOffset?: number | null, list: Array<{ __typename?: 'Row', columnValues: Array<{ __typename?: 'ColumnValue', displayValue: string }> }> } };
 
+export type RowWithDiffListRowsFragment = { __typename?: 'RowWithDiffList', nextOffset?: number | null, list: Array<{ __typename?: 'Row', columnValues: Array<{ __typename?: 'ColumnValue', displayValue: string }> }>, diffs?: Array<{ __typename?: 'RowWithDiff', index: number, diffType: string }> | null };
+
+export type RowsWithDiffForDataTableQueryVariables = Exact<{
+  databaseName: Scalars['String']['input'];
+  refName: Scalars['String']['input'];
+  tableName: Scalars['String']['input'];
+  schemaName?: InputMaybe<Scalars['String']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+}>;
+
+
+export type RowsWithDiffForDataTableQuery = { __typename?: 'Query', rowsWithWorkingDiff: { __typename?: 'RowWithDiffList', nextOffset?: number | null, list: Array<{ __typename?: 'Row', columnValues: Array<{ __typename?: 'ColumnValue', displayValue: string }> }>, diffs?: Array<{ __typename?: 'RowWithDiff', index: number, diffType: string }> | null } };
+
 export type DiffSummaryFragment = { __typename?: 'DiffSummary', _id: string, fromTableName: string, toTableName: string, tableName: string, tableType: TableDiffType, hasDataChanges: boolean, hasSchemaChanges: boolean };
 
 export type DiffSummariesQueryVariables = Exact<{
@@ -2121,6 +2157,18 @@ export const RowListRowsFragmentDoc = gql`
   nextOffset
   list {
     ...RowForDataTable
+  }
+}
+    ${RowForDataTableFragmentDoc}`;
+export const RowWithDiffListRowsFragmentDoc = gql`
+    fragment RowWithDiffListRows on RowWithDiffList {
+  nextOffset
+  list {
+    ...RowForDataTable
+  }
+  diffs {
+    index
+    diffType
   }
 }
     ${RowForDataTableFragmentDoc}`;
@@ -4905,6 +4953,56 @@ export type RowsForDataTableQueryHookResult = ReturnType<typeof useRowsForDataTa
 export type RowsForDataTableQueryLazyQueryHookResult = ReturnType<typeof useRowsForDataTableQueryLazyQuery>;
 export type RowsForDataTableQuerySuspenseQueryHookResult = ReturnType<typeof useRowsForDataTableQuerySuspenseQuery>;
 export type RowsForDataTableQueryQueryResult = Apollo.QueryResult<RowsForDataTableQuery, RowsForDataTableQueryVariables>;
+export const RowsWithDiffForDataTableQueryDocument = gql`
+    query RowsWithDiffForDataTableQuery($databaseName: String!, $refName: String!, $tableName: String!, $schemaName: String, $offset: Int) {
+  rowsWithWorkingDiff(
+    databaseName: $databaseName
+    refName: $refName
+    tableName: $tableName
+    schemaName: $schemaName
+    offset: $offset
+  ) {
+    ...RowWithDiffListRows
+  }
+}
+    ${RowWithDiffListRowsFragmentDoc}`;
+
+/**
+ * __useRowsWithDiffForDataTableQuery__
+ *
+ * To run a query within a React component, call `useRowsWithDiffForDataTableQuery` and pass it any options that fit your needs.
+ * When your component renders, `useRowsWithDiffForDataTableQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useRowsWithDiffForDataTableQuery({
+ *   variables: {
+ *      databaseName: // value for 'databaseName'
+ *      refName: // value for 'refName'
+ *      tableName: // value for 'tableName'
+ *      schemaName: // value for 'schemaName'
+ *      offset: // value for 'offset'
+ *   },
+ * });
+ */
+export function useRowsWithDiffForDataTableQuery(baseOptions: Apollo.QueryHookOptions<RowsWithDiffForDataTableQuery, RowsWithDiffForDataTableQueryVariables> & ({ variables: RowsWithDiffForDataTableQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<RowsWithDiffForDataTableQuery, RowsWithDiffForDataTableQueryVariables>(RowsWithDiffForDataTableQueryDocument, options);
+      }
+export function useRowsWithDiffForDataTableQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RowsWithDiffForDataTableQuery, RowsWithDiffForDataTableQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<RowsWithDiffForDataTableQuery, RowsWithDiffForDataTableQueryVariables>(RowsWithDiffForDataTableQueryDocument, options);
+        }
+export function useRowsWithDiffForDataTableQuerySuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<RowsWithDiffForDataTableQuery, RowsWithDiffForDataTableQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<RowsWithDiffForDataTableQuery, RowsWithDiffForDataTableQueryVariables>(RowsWithDiffForDataTableQueryDocument, options);
+        }
+export type RowsWithDiffForDataTableQueryHookResult = ReturnType<typeof useRowsWithDiffForDataTableQuery>;
+export type RowsWithDiffForDataTableQueryLazyQueryHookResult = ReturnType<typeof useRowsWithDiffForDataTableQueryLazyQuery>;
+export type RowsWithDiffForDataTableQuerySuspenseQueryHookResult = ReturnType<typeof useRowsWithDiffForDataTableQuerySuspenseQuery>;
+export type RowsWithDiffForDataTableQueryQueryResult = Apollo.QueryResult<RowsWithDiffForDataTableQuery, RowsWithDiffForDataTableQueryVariables>;
 export const DiffSummariesDocument = gql`
     query DiffSummaries($databaseName: String!, $fromRefName: String!, $toRefName: String!, $refName: String, $type: CommitDiffType) {
   diffSummaries(


### PR DESCRIPTION
This adds row highlighting based on changes to the working set. Right now, this will only apply to the base `select *` query that runs when you open a table. 
<img width="1490" height="577" alt="Screenshot 2025-10-03 at 11 56 55 AM" src="https://github.com/user-attachments/assets/73f58d71-471f-4ec4-aacf-85c6fb329588" />
