### PR TITLE
Move connection url parsing to graphql

### DIFF
--- a/graphql-server/schema.gql
+++ b/graphql-server/schema.gql
@@ -106,6 +106,9 @@ type DatabaseConnection {
   type: DatabaseType
   isDolt: Boolean
   isLocalDolt: Boolean
+  host: String
+  user: String
+  password: String
 }
 
 enum DatabaseType {

--- a/graphql-server/src/connections/util.ts
+++ b/graphql-server/src/connections/util.ts
@@ -6,3 +6,22 @@ export function replaceDatabaseInConnectionUrl(
   url.pathname = `/${dbName}`;
   return url.toString();
 }
+
+export type ParsedConnectionUrl = {
+  host?: string;
+  user?: string;
+  password?: string;
+};
+
+export function parseConnectionUrl(connectionUrl: string): ParsedConnectionUrl {
+  try {
+    const url = new URL(connectionUrl);
+    return {
+      host: url.hostname || undefined,
+      user: url.username ? decodeURIComponent(url.username) : undefined,
+      password: url.password ? decodeURIComponent(url.password) : undefined,
+    };
+  } catch {
+    return {};
+  }
+}

--- a/graphql-server/src/databases/database.model.ts
+++ b/graphql-server/src/databases/database.model.ts
@@ -26,4 +26,13 @@ export class DatabaseConnection {
 
   @Field({ nullable: true })
   isLocalDolt?: boolean;
+
+  @Field({ nullable: true })
+  host?: string;
+
+  @Field({ nullable: true })
+  user?: string;
+
+  @Field({ nullable: true })
+  password?: string;
 }

--- a/graphql-server/src/databases/database.resolver.ts
+++ b/graphql-server/src/databases/database.resolver.ts
@@ -13,6 +13,7 @@ import {
   newQueryFactory,
   WorkbenchConfig,
 } from "../connections/connection.provider";
+import { parseConnectionUrl } from "../connections/util";
 import { DataStoreService } from "../dataStore/dataStore.service";
 import { FileStoreService } from "../fileStore/fileStore.service";
 import {
@@ -109,6 +110,7 @@ export class DatabaseResolver {
       config.connectionUrl.startsWith(x.connectionUrl),
     )?.name;
     if (!connectionName) return undefined;
+    const parsed = parseConnectionUrl(config.connectionUrl);
     return {
       connectionUrl: config.connectionUrl,
       name: connectionName,
@@ -118,6 +120,9 @@ export class DatabaseResolver {
       type: config.type,
       isDolt,
       isLocalDolt: config.isLocalDolt,
+      host: parsed.host,
+      user: parsed.user,
+      password: parsed.password,
     };
   }
 

--- a/web/renderer/components/DatabaseHeaderAndNav/queries.ts
+++ b/web/renderer/components/DatabaseHeaderAndNav/queries.ts
@@ -23,6 +23,9 @@ export const CURRENT_CONNECTION = gql`
       type
       isDolt
       isLocalDolt
+      host
+      user
+      password
     }
   }
 `;

--- a/web/renderer/components/layouts/DatabaseLayout/useAgentLayout.ts
+++ b/web/renderer/components/layouts/DatabaseLayout/useAgentLayout.ts
@@ -5,26 +5,6 @@ import { ref } from "@lib/urls";
 import { useRouter } from "next/router";
 import { CSSProperties, useEffect } from "react";
 
-function parseConnectionUrl(connectionUrl: string): {
-  host: string;
-  port: number;
-  user: string;
-  password?: string;
-} {
-  try {
-    const url = new URL(connectionUrl);
-    return {
-      host: url.hostname || "127.0.0.1",
-      port: parseInt(url.port, 10) || 3306,
-      user: url.username || "root",
-      password: url.password || undefined,
-    };
-  } catch (e) {
-    console.error("parseConnectionUrl error:", e);
-    return { host: "127.0.0.1", port: 3306, user: "root" };
-  }
-}
-
 type AgentLayoutState = {
   contentStyle: CSSProperties;
 };
@@ -42,12 +22,13 @@ export default function useAgentLayout(
 
   // Update MCP config in global agent context when connection changes
   useEffect(() => {
-    if (connectionData?.currentConnection?.connectionUrl) {
-      const conn = connectionData.currentConnection;
-      const parsed = parseConnectionUrl(conn.connectionUrl);
+    const conn = connectionData?.currentConnection;
+    if (conn?.host) {
       const config: McpServerConfig = {
-        ...parsed,
-        port: conn.port ? parseInt(conn.port, 10) : parsed.port,
+        host: conn.host,
+        port: conn.port ? parseInt(conn.port, 10) : 3306,
+        user: conn.user ?? "root",
+        password: conn.password ?? undefined,
         database: databaseName,
         useSSL: conn.useSSL ?? false,
         type: conn.type ?? undefined,
@@ -62,10 +43,13 @@ export default function useAgentLayout(
       setMcpConfig(null);
     };
   }, [
-    connectionData?.currentConnection?.connectionUrl,
+    connectionData?.currentConnection?.host,
+    connectionData?.currentConnection?.user,
+    connectionData?.currentConnection?.password,
     connectionData?.currentConnection?.port,
     connectionData?.currentConnection?.useSSL,
     connectionData?.currentConnection?.type,
+    connectionData?.currentConnection?.isDolt,
     databaseName,
     setMcpConfig,
   ]);

--- a/web/renderer/gen/graphql-types.tsx
+++ b/web/renderer/gen/graphql-types.tsx
@@ -106,12 +106,15 @@ export type DatabaseConnection = {
   __typename?: 'DatabaseConnection';
   connectionUrl: Scalars['String']['output'];
   hideDoltFeatures?: Maybe<Scalars['Boolean']['output']>;
+  host?: Maybe<Scalars['String']['output']>;
   isDolt?: Maybe<Scalars['Boolean']['output']>;
   isLocalDolt?: Maybe<Scalars['Boolean']['output']>;
   name: Scalars['String']['output'];
+  password?: Maybe<Scalars['String']['output']>;
   port?: Maybe<Scalars['String']['output']>;
   type?: Maybe<DatabaseType>;
   useSSL?: Maybe<Scalars['Boolean']['output']>;
+  user?: Maybe<Scalars['String']['output']>;
 };
 
 export enum DatabaseType {
@@ -1046,7 +1049,7 @@ export type ResetDatabaseMutation = { __typename?: 'Mutation', resetDatabase: bo
 export type CurrentConnectionQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type CurrentConnectionQuery = { __typename?: 'Query', currentConnection?: { __typename?: 'DatabaseConnection', connectionUrl: string, name: string, port?: string | null, hideDoltFeatures?: boolean | null, useSSL?: boolean | null, type?: DatabaseType | null, isDolt?: boolean | null, isLocalDolt?: boolean | null } | null };
+export type CurrentConnectionQuery = { __typename?: 'Query', currentConnection?: { __typename?: 'DatabaseConnection', connectionUrl: string, name: string, port?: string | null, hideDoltFeatures?: boolean | null, useSSL?: boolean | null, type?: DatabaseType | null, isDolt?: boolean | null, isLocalDolt?: boolean | null, host?: string | null, user?: string | null, password?: string | null } | null };
 
 export type DatabasesByConnectionQueryVariables = Exact<{
   connectionUrl: Scalars['String']['input'];
@@ -2379,6 +2382,9 @@ export const CurrentConnectionDocument = gql`
     type
     isDolt
     isLocalDolt
+    host
+    user
+    password
   }
 }
     `;


### PR DESCRIPTION
Chromium url parsing is known to be buggy/inconsistent. This was causing connection issues with postgres/doltgres. Centralizing that logic in graphql-server fixes it.