### PR TITLE
Add mutations for DROP COLUMN and DROP TABLE

### DIFF
--- a/graphql-server/schema.gql
+++ b/graphql-server/schema.gql
@@ -488,6 +488,8 @@ type Mutation {
   deleteRow(schemaName: String, tableName: String!, refName: String!, databaseName: String!, where: [ColumnValueInput!]!): MutationResult!
   insertRow(schemaName: String, tableName: String!, refName: String!, databaseName: String!, values: [ColumnValueInput!]!): MutationResult!
   updateRow(schemaName: String, tableName: String!, refName: String!, databaseName: String!, set: [ColumnValueInput!]!, where: [ColumnValueInput!]!): MutationResult!
+  dropColumn(schemaName: String, tableName: String!, refName: String!, databaseName: String!, columnName: String!): MutationResult!
+  dropTable(schemaName: String, tableName: String!, refName: String!, databaseName: String!): MutationResult!
   restoreAllTables(databaseName: String!, refName: String!): Boolean!
   createTag(tagName: String!, databaseName: String!, message: String, fromRefName: String!, author: AuthorInfo): String!
   deleteTag(databaseName: String!, tagName: String!): Boolean!

--- a/graphql-server/schema.gql
+++ b/graphql-server/schema.gql
@@ -489,7 +489,7 @@ type Mutation {
   insertRow(schemaName: String, tableName: String!, refName: String!, databaseName: String!, values: [ColumnValueInput!]!): MutationResult!
   updateRow(schemaName: String, tableName: String!, refName: String!, databaseName: String!, set: [ColumnValueInput!]!, where: [ColumnValueInput!]!): MutationResult!
   dropColumn(schemaName: String, tableName: String!, refName: String!, databaseName: String!, columnName: String!): MutationResult!
-  dropTable(schemaName: String, tableName: String!, refName: String!, databaseName: String!): MutationResult!
+  dropTable(tableName: String!, refName: String!, databaseName: String!, schemaName: String): MutationResult!
   restoreAllTables(databaseName: String!, refName: String!): Boolean!
   createTag(tagName: String!, databaseName: String!, message: String, fromRefName: String!, author: AuthorInfo): String!
   deleteTag(databaseName: String!, tagName: String!): Boolean!

--- a/graphql-server/src/queryFactory/build/buildDeleteRow.ts
+++ b/graphql-server/src/queryFactory/build/buildDeleteRow.ts
@@ -1,23 +1,17 @@
 import { DeleteResult, EntityManager } from "typeorm";
 import { ColumnValue } from "../types";
 import {
+  Built,
   buildWhereConditions,
   interpolateForDisplay,
   newParamAccumulator,
 } from "./buildUtils";
 
-export type BuiltDelete = {
-  sql: string;
-  params: string[];
-  displaySql: string;
-  execute: () => Promise<DeleteResult>;
-};
-
 export function buildDeleteRow(
   em: EntityManager,
   target: string,
   where: ColumnValue[],
-): BuiltDelete {
+): Built<DeleteResult> {
   if (where.length === 0) {
     throw new Error("deleteRow requires at least one where clause");
   }

--- a/graphql-server/src/queryFactory/build/buildDropColumn.test.ts
+++ b/graphql-server/src/queryFactory/build/buildDropColumn.test.ts
@@ -1,0 +1,39 @@
+import { DataSource, EntityManager } from "typeorm";
+import { buildDropColumn } from "./buildDropColumn";
+
+const mysqlEm = new EntityManager(
+  new DataSource({ type: "mysql", host: "", database: "" }),
+);
+const pgEm = new EntityManager(
+  new DataSource({ type: "postgres", host: "", database: "" }),
+);
+
+describe("buildDropColumn", () => {
+  describe("mysql", () => {
+    it("emits ALTER TABLE ... DROP COLUMN with backtick identifiers", () => {
+      const out = buildDropColumn(mysqlEm, "users", "email");
+      expect(out.sql).toBe("ALTER TABLE `users` DROP COLUMN `email`");
+      expect(out.params).toEqual([]);
+      expect(out.displaySql).toBe(out.sql);
+    });
+  });
+
+  describe("postgres", () => {
+    it("emits ALTER TABLE ... DROP COLUMN with double-quoted identifiers", () => {
+      const out = buildDropColumn(pgEm, "public.users", "email");
+      expect(out.sql).toBe('ALTER TABLE "public"."users" DROP COLUMN "email"');
+      expect(out.params).toEqual([]);
+      expect(out.displaySql).toBe(out.sql);
+    });
+
+    it("uses the supplied schema (non-public)", () => {
+      const out = buildDropColumn(pgEm, "analytics.events", "ts");
+      expect(out.sql).toBe('ALTER TABLE "analytics"."events" DROP COLUMN "ts"');
+    });
+
+    it("emits an unqualified table when no schema is in target", () => {
+      const out = buildDropColumn(pgEm, "users", "email");
+      expect(out.sql).toBe('ALTER TABLE "users" DROP COLUMN "email"');
+    });
+  });
+});

--- a/graphql-server/src/queryFactory/build/buildDropColumn.ts
+++ b/graphql-server/src/queryFactory/build/buildDropColumn.ts
@@ -1,0 +1,17 @@
+import { EntityManager } from "typeorm";
+import { Built, escapeQualifiedIdentifier } from "./buildUtils";
+
+export function buildDropColumn(
+  em: EntityManager,
+  target: string,
+  columnName: string,
+): Built<unknown> {
+  const escape = em.connection.driver.escape.bind(em.connection.driver);
+  const sql = `ALTER TABLE ${escapeQualifiedIdentifier(escape, target)} DROP COLUMN ${escape(columnName)}`;
+  return {
+    sql,
+    params: [],
+    displaySql: sql,
+    execute: async () => em.query(sql),
+  };
+}

--- a/graphql-server/src/queryFactory/build/buildDropTable.test.ts
+++ b/graphql-server/src/queryFactory/build/buildDropTable.test.ts
@@ -1,0 +1,39 @@
+import { DataSource, EntityManager } from "typeorm";
+import { buildDropTable } from "./buildDropTable";
+
+const mysqlEm = new EntityManager(
+  new DataSource({ type: "mysql", host: "", database: "" }),
+);
+const pgEm = new EntityManager(
+  new DataSource({ type: "postgres", host: "", database: "" }),
+);
+
+describe("buildDropTable", () => {
+  describe("mysql", () => {
+    it("emits DROP TABLE with backtick identifiers", () => {
+      const out = buildDropTable(mysqlEm, "users");
+      expect(out.sql).toBe("DROP TABLE `users`");
+      expect(out.params).toEqual([]);
+      expect(out.displaySql).toBe(out.sql);
+    });
+  });
+
+  describe("postgres", () => {
+    it("emits DROP TABLE with double-quoted, schema-qualified identifier", () => {
+      const out = buildDropTable(pgEm, "public.users");
+      expect(out.sql).toBe('DROP TABLE "public"."users"');
+      expect(out.params).toEqual([]);
+      expect(out.displaySql).toBe(out.sql);
+    });
+
+    it("uses the supplied schema (non-public)", () => {
+      const out = buildDropTable(pgEm, "analytics.events");
+      expect(out.sql).toBe('DROP TABLE "analytics"."events"');
+    });
+
+    it("emits an unqualified table when no schema is in target", () => {
+      const out = buildDropTable(pgEm, "users");
+      expect(out.sql).toBe('DROP TABLE "users"');
+    });
+  });
+});

--- a/graphql-server/src/queryFactory/build/buildDropTable.ts
+++ b/graphql-server/src/queryFactory/build/buildDropTable.ts
@@ -1,0 +1,16 @@
+import { EntityManager } from "typeorm";
+import { Built, escapeQualifiedIdentifier } from "./buildUtils";
+
+export function buildDropTable(
+  em: EntityManager,
+  target: string,
+): Built<unknown> {
+  const escape = em.connection.driver.escape.bind(em.connection.driver);
+  const sql = `DROP TABLE ${escapeQualifiedIdentifier(escape, target)}`;
+  return {
+    sql,
+    params: [],
+    displaySql: sql,
+    execute: async () => em.query(sql),
+  };
+}

--- a/graphql-server/src/queryFactory/build/buildInsertRow.ts
+++ b/graphql-server/src/queryFactory/build/buildInsertRow.ts
@@ -1,23 +1,17 @@
 import { EntityManager, InsertResult } from "typeorm";
 import { ColumnValue } from "../types";
 import {
+  Built,
   buildColumnValueMap,
   interpolateForDisplay,
   newParamAccumulator,
 } from "./buildUtils";
 
-export type BuiltInsert = {
-  sql: string;
-  params: string[];
-  displaySql: string;
-  execute: () => Promise<InsertResult>;
-};
-
 export function buildInsertRow(
   em: EntityManager,
   target: string,
   values: ColumnValue[],
-): BuiltInsert {
+): Built<InsertResult> {
   if (values.length === 0) {
     throw new Error("insertRow requires at least one column value");
   }

--- a/graphql-server/src/queryFactory/build/buildUpdateRow.ts
+++ b/graphql-server/src/queryFactory/build/buildUpdateRow.ts
@@ -1,25 +1,19 @@
 import { EntityManager, UpdateResult } from "typeorm";
 import { ColumnValue } from "../types";
 import {
+  Built,
   buildColumnValueMap,
   buildWhereConditions,
   interpolateForDisplay,
   newParamAccumulator,
 } from "./buildUtils";
 
-export type BuiltUpdate = {
-  sql: string;
-  params: string[];
-  displaySql: string;
-  execute: () => Promise<UpdateResult>;
-};
-
 export function buildUpdateRow(
   em: EntityManager,
   target: string,
   set: ColumnValue[],
   where: ColumnValue[],
-): BuiltUpdate {
+): Built<UpdateResult> {
   if (set.length === 0) {
     throw new Error("updateRow requires at least one set clause");
   }

--- a/graphql-server/src/queryFactory/build/buildUtils.ts
+++ b/graphql-server/src/queryFactory/build/buildUtils.ts
@@ -1,8 +1,24 @@
 import { pluralize } from "@dolthub/web-utils";
 import { ColumnValue } from "../types";
 
+export type Built<TResult> = {
+  sql: string;
+  params: string[];
+  displaySql: string;
+  execute: () => Promise<TResult>;
+};
+
 export function mutationExecutionMessage(rowsAffected: number): string {
   return `Query OK, ${rowsAffected} ${pluralize(rowsAffected, "row")} affected.`;
+}
+
+export const DDL_EXECUTION_MESSAGE = "Query OK.";
+
+export function escapeQualifiedIdentifier(
+  escape: (name: string) => string,
+  qualified: string,
+): string {
+  return qualified.split(".").map(escape).join(".");
 }
 
 export function escapeStringLiteral(s: string): string {

--- a/graphql-server/src/queryFactory/index.ts
+++ b/graphql-server/src/queryFactory/index.ts
@@ -85,7 +85,7 @@ export declare class QueryFactory {
 
   dropColumn(args: t.DropColumnArgs): Promise<t.MutationResult>;
 
-  dropTable(args: t.DropTableArgs): Promise<t.MutationResult>;
+  dropTable(args: t.TableMaybeSchemaArgs): Promise<t.MutationResult>;
 
   getSchemas(
     args: t.RefMaybeSchemaArgs,

--- a/graphql-server/src/queryFactory/index.ts
+++ b/graphql-server/src/queryFactory/index.ts
@@ -83,6 +83,10 @@ export declare class QueryFactory {
 
   updateRow(args: t.UpdateRowArgs): Promise<t.MutationResult>;
 
+  dropColumn(args: t.DropColumnArgs): Promise<t.MutationResult>;
+
+  dropTable(args: t.DropTableArgs): Promise<t.MutationResult>;
+
   getSchemas(
     args: t.RefMaybeSchemaArgs,
     type?: SchemaType,

--- a/graphql-server/src/queryFactory/mysql/index.ts
+++ b/graphql-server/src/queryFactory/mysql/index.ts
@@ -6,9 +6,14 @@ import { TableDetails } from "../../tables/table.model";
 import { BaseQueryFactory } from "../base";
 import * as t from "../types";
 import { buildDeleteRow } from "../build/buildDeleteRow";
+import { buildDropColumn } from "../build/buildDropColumn";
+import { buildDropTable } from "../build/buildDropTable";
 import { buildInsertRow } from "../build/buildInsertRow";
 import { buildUpdateRow } from "../build/buildUpdateRow";
-import { mutationExecutionMessage } from "../build/buildUtils";
+import {
+  DDL_EXECUTION_MESSAGE,
+  mutationExecutionMessage,
+} from "../build/buildUtils";
 import { classifyMysqlResult } from "./classifyResult";
 import * as qh from "./queries";
 import {
@@ -203,6 +208,42 @@ export class MySQLQueryFactory
           rowsAffected,
           queryString: built.displaySql,
           executionMessage: mutationExecutionMessage(rowsAffected),
+        };
+      },
+      args.databaseName,
+      args.refName,
+    );
+  }
+
+  async dropColumn(args: t.DropColumnArgs): Promise<t.MutationResult> {
+    return this.queryQR(
+      async qr => {
+        const built = buildDropColumn(
+          qr.manager,
+          args.tableName,
+          args.columnName,
+        );
+        await built.execute();
+        return {
+          rowsAffected: 0,
+          queryString: built.displaySql,
+          executionMessage: DDL_EXECUTION_MESSAGE,
+        };
+      },
+      args.databaseName,
+      args.refName,
+    );
+  }
+
+  async dropTable(args: t.DropTableArgs): Promise<t.MutationResult> {
+    return this.queryQR(
+      async qr => {
+        const built = buildDropTable(qr.manager, args.tableName);
+        await built.execute();
+        return {
+          rowsAffected: 0,
+          queryString: built.displaySql,
+          executionMessage: DDL_EXECUTION_MESSAGE,
         };
       },
       args.databaseName,

--- a/graphql-server/src/queryFactory/mysql/index.ts
+++ b/graphql-server/src/queryFactory/mysql/index.ts
@@ -235,7 +235,7 @@ export class MySQLQueryFactory
     );
   }
 
-  async dropTable(args: t.DropTableArgs): Promise<t.MutationResult> {
+  async dropTable(args: t.TableMaybeSchemaArgs): Promise<t.MutationResult> {
     return this.queryQR(
       async qr => {
         const built = buildDropTable(qr.manager, args.tableName);

--- a/graphql-server/src/queryFactory/postgres/index.ts
+++ b/graphql-server/src/queryFactory/postgres/index.ts
@@ -14,9 +14,14 @@ import * as t from "../types";
 import * as qh from "./queries";
 import { changeSchema, getSchema, tableWithSchema } from "./utils";
 import { buildDeleteRow } from "../build/buildDeleteRow";
+import { buildDropColumn } from "../build/buildDropColumn";
+import { buildDropTable } from "../build/buildDropTable";
 import { buildInsertRow } from "../build/buildInsertRow";
 import { buildUpdateRow } from "../build/buildUpdateRow";
-import { mutationExecutionMessage } from "../build/buildUtils";
+import {
+  DDL_EXECUTION_MESSAGE,
+  mutationExecutionMessage,
+} from "../build/buildUtils";
 import { classifyPgResult } from "./classifyResult";
 
 export class PostgresQueryFactory
@@ -212,6 +217,48 @@ export class PostgresQueryFactory
           rowsAffected,
           queryString: built.displaySql,
           executionMessage: mutationExecutionMessage(rowsAffected),
+        };
+      },
+      args.databaseName,
+      args.refName,
+    );
+  }
+
+  async dropColumn(args: t.DropColumnArgs): Promise<t.MutationResult> {
+    return this.queryQR(
+      async qr => {
+        const schemaName = await getSchema(qr, args);
+        const target = tableWithSchema({
+          tableName: args.tableName,
+          schemaName,
+        });
+        const built = buildDropColumn(qr.manager, target, args.columnName);
+        await built.execute();
+        return {
+          rowsAffected: 0,
+          queryString: built.displaySql,
+          executionMessage: DDL_EXECUTION_MESSAGE,
+        };
+      },
+      args.databaseName,
+      args.refName,
+    );
+  }
+
+  async dropTable(args: t.DropTableArgs): Promise<t.MutationResult> {
+    return this.queryQR(
+      async qr => {
+        const schemaName = await getSchema(qr, args);
+        const target = tableWithSchema({
+          tableName: args.tableName,
+          schemaName,
+        });
+        const built = buildDropTable(qr.manager, target);
+        await built.execute();
+        return {
+          rowsAffected: 0,
+          queryString: built.displaySql,
+          executionMessage: DDL_EXECUTION_MESSAGE,
         };
       },
       args.databaseName,

--- a/graphql-server/src/queryFactory/postgres/index.ts
+++ b/graphql-server/src/queryFactory/postgres/index.ts
@@ -245,7 +245,7 @@ export class PostgresQueryFactory
     );
   }
 
-  async dropTable(args: t.DropTableArgs): Promise<t.MutationResult> {
+  async dropTable(args: t.TableMaybeSchemaArgs): Promise<t.MutationResult> {
     return this.queryQR(
       async qr => {
         const schemaName = await getSchema(qr, args);

--- a/graphql-server/src/queryFactory/types.ts
+++ b/graphql-server/src/queryFactory/types.ts
@@ -82,29 +82,21 @@ export type ColumnValue = {
   type?: string;
 };
 
-export type DeleteRowArgs = RefMaybeSchemaArgs & {
-  tableName: string;
+export type DeleteRowArgs = TableMaybeSchemaArgs & {
   where: ColumnValue[];
 };
 
-export type InsertRowArgs = RefMaybeSchemaArgs & {
-  tableName: string;
+export type InsertRowArgs = TableMaybeSchemaArgs & {
   values: ColumnValue[];
 };
 
-export type UpdateRowArgs = RefMaybeSchemaArgs & {
-  tableName: string;
+export type UpdateRowArgs = TableMaybeSchemaArgs & {
   set: ColumnValue[];
   where: ColumnValue[];
 };
 
-export type DropColumnArgs = RefMaybeSchemaArgs & {
-  tableName: string;
+export type DropColumnArgs = TableMaybeSchemaArgs & {
   columnName: string;
-};
-
-export type DropTableArgs = RefMaybeSchemaArgs & {
-  tableName: string;
 };
 
 export type MutationResult = {

--- a/graphql-server/src/queryFactory/types.ts
+++ b/graphql-server/src/queryFactory/types.ts
@@ -98,6 +98,15 @@ export type UpdateRowArgs = RefMaybeSchemaArgs & {
   where: ColumnValue[];
 };
 
+export type DropColumnArgs = RefMaybeSchemaArgs & {
+  tableName: string;
+  columnName: string;
+};
+
+export type DropTableArgs = RefMaybeSchemaArgs & {
+  tableName: string;
+};
+
 export type MutationResult = {
   rowsAffected: number;
   queryString: string;

--- a/graphql-server/src/rows/rowMutation.resolver.ts
+++ b/graphql-server/src/rows/rowMutation.resolver.ts
@@ -56,6 +56,15 @@ export class UpdateRowArgs extends TableMaybeSchemaArgs {
   where: ColumnValueInput[];
 }
 
+@ArgsType()
+export class DropColumnArgs extends TableMaybeSchemaArgs {
+  @Field()
+  columnName: string;
+}
+
+@ArgsType()
+export class DropTableArgs extends TableMaybeSchemaArgs {}
+
 @Resolver()
 export class RowMutationResolver {
   constructor(private readonly conn: ConnectionProvider) {}
@@ -76,5 +85,17 @@ export class RowMutationResolver {
   async updateRow(@Args() args: UpdateRowArgs): Promise<MutationResult> {
     const conn = this.conn.connection();
     return conn.updateRow(args);
+  }
+
+  @Mutation(_returns => MutationResult)
+  async dropColumn(@Args() args: DropColumnArgs): Promise<MutationResult> {
+    const conn = this.conn.connection();
+    return conn.dropColumn(args);
+  }
+
+  @Mutation(_returns => MutationResult)
+  async dropTable(@Args() args: DropTableArgs): Promise<MutationResult> {
+    const conn = this.conn.connection();
+    return conn.dropTable(args);
   }
 }

--- a/graphql-server/src/rows/rowMutation.resolver.ts
+++ b/graphql-server/src/rows/rowMutation.resolver.ts
@@ -62,9 +62,6 @@ export class DropColumnArgs extends TableMaybeSchemaArgs {
   columnName: string;
 }
 
-@ArgsType()
-export class DropTableArgs extends TableMaybeSchemaArgs {}
-
 @Resolver()
 export class RowMutationResolver {
   constructor(private readonly conn: ConnectionProvider) {}
@@ -94,7 +91,7 @@ export class RowMutationResolver {
   }
 
   @Mutation(_returns => MutationResult)
-  async dropTable(@Args() args: DropTableArgs): Promise<MutationResult> {
+  async dropTable(@Args() args: TableMaybeSchemaArgs): Promise<MutationResult> {
     const conn = this.conn.connection();
     return conn.dropTable(args);
   }

--- a/web/renderer/components/CellButtons/DropColumnButton.tsx
+++ b/web/renderer/components/CellButtons/DropColumnButton.tsx
@@ -1,10 +1,15 @@
 import HideForNoWritesWrapper from "@components/util/HideForNoWritesWrapper";
+import { useApolloClient } from "@apollo/client";
 import { useDataTableContext } from "@contexts/dataTable";
 import { useSqlEditorContext } from "@contexts/sqleditor";
 import { Button } from "@dolthub/react-components";
-import { ColumnForDataTableFragment } from "@gen/graphql-types";
-import useSqlBuilder from "@hooks/useSqlBuilder";
+import {
+  ColumnForDataTableFragment,
+  useDropColumnMutation,
+} from "@gen/graphql-types";
+import useMutation from "@hooks/useMutation";
 import { isDoltSystemTable } from "@lib/doltSystemTables";
+import { refetchUpdateDatabaseQueriesCacheEvict } from "@lib/refetchQueries";
 import css from "./index.module.css";
 
 type Props = {
@@ -13,26 +18,37 @@ type Props = {
 };
 
 export default function DropColumnButton({ col, refName }: Props) {
-  const { executeQuery, setEditorString } = useSqlEditorContext();
+  const { setEditorString, setError, setExecutionMessage } =
+    useSqlEditorContext();
   const { params } = useDataTableContext();
-  const { tableName } = params;
-  const { alterTableDropColQuery } = useSqlBuilder();
+  const { tableName, schemaName, databaseName } = params;
+  const effectiveRefName = refName ?? params.refName;
+  const client = useApolloClient();
+  const { mutateFn: dropColumn } = useMutation({ hook: useDropColumnMutation });
 
   if (!tableName || !col.sourceTable || isDoltSystemTable(tableName)) {
     return null;
   }
 
   const onClick = async () => {
-    const query = alterTableDropColQuery(
-      col.sourceTable ?? tableName,
-      col.name,
-    );
-    setEditorString(query);
-    await executeQuery({
-      ...params,
-      refName: refName ?? params.refName,
-      query,
+    const res = await dropColumn({
+      variables: {
+        databaseName,
+        refName: effectiveRefName,
+        schemaName,
+        tableName: col.sourceTable ?? tableName,
+        columnName: col.name,
+      },
     });
+    if (res.success && res.data?.dropColumn) {
+      setEditorString(res.data.dropColumn.queryString);
+      setExecutionMessage(res.data.dropColumn.executionMessage);
+      client
+        .refetchQueries(refetchUpdateDatabaseQueriesCacheEvict)
+        .catch(console.error);
+    } else if (res.error) {
+      setError(res.error);
+    }
   };
 
   return (

--- a/web/renderer/components/CellButtons/queries.ts
+++ b/web/renderer/components/CellButtons/queries.ts
@@ -67,3 +67,25 @@ export const UPDATE_ROW = gql`
     }
   }
 `;
+
+export const DROP_COLUMN = gql`
+  mutation DropColumn(
+    $databaseName: String!
+    $refName: String!
+    $schemaName: String
+    $tableName: String!
+    $columnName: String!
+  ) {
+    dropColumn(
+      databaseName: $databaseName
+      refName: $refName
+      schemaName: $schemaName
+      tableName: $tableName
+      columnName: $columnName
+    ) {
+      rowsAffected
+      queryString
+      executionMessage
+    }
+  }
+`;

--- a/web/renderer/components/DataTable/Table/Row.tsx
+++ b/web/renderer/components/DataTable/Table/Row.tsx
@@ -48,10 +48,11 @@ export default function Row(props: Props) {
           </CellDropdown>
         )}
       </td>
-      {props.row.columnValues.map((c, cidx) => (
-        // eslint-disable-next-line react/jsx-key
-        <Cell {...props} cell={c} cidx={cidx} />
-      ))}
+      {props.row.columnValues
+        .slice(0, props.columns.length)
+        .map((cell, cidx) => (
+          <Cell key={cidx} {...props} cell={cell} cidx={cidx} />
+        ))}
     </tr>
   );
 }

--- a/web/renderer/components/DataTable/Table/Row.tsx
+++ b/web/renderer/components/DataTable/Table/Row.tsx
@@ -24,6 +24,11 @@ type Props = {
 
 export default function Row(props: Props) {
   const [showDropdown, setShowDropdown] = useState(false);
+
+  if (props.row.columnValues.length !== props.columns.length) {
+    return null;
+  }
+
   const diffTypeClassName = getDiffTypeClassNameForRow(
     props.row,
     props.columns,
@@ -48,11 +53,9 @@ export default function Row(props: Props) {
           </CellDropdown>
         )}
       </td>
-      {props.row.columnValues
-        .slice(0, props.columns.length)
-        .map((cell, cidx) => (
-          <Cell key={cidx} {...props} cell={cell} cidx={cidx} />
-        ))}
+      {props.row.columnValues.map((cell, cidx) => (
+        <Cell key={cidx} {...props} cell={cell} cidx={cidx} />
+      ))}
     </tr>
   );
 }

--- a/web/renderer/components/pageComponents/DatabasePage/ForTable/EditTableButtons.tsx
+++ b/web/renderer/components/pageComponents/DatabasePage/ForTable/EditTableButtons.tsx
@@ -1,24 +1,28 @@
 import DatabaseUploadStageLink from "@components/links/DatabaseUploadStageLink";
 import Link from "@components/links/Link";
+import { useApolloClient } from "@apollo/client";
 import { useDataTableContext } from "@contexts/dataTable";
 import { useSqlEditorContext } from "@contexts/sqleditor";
 import { Button, ErrorMsg } from "@dolthub/react-components";
 import {
   ColumnValueInput,
+  useDropTableMutation,
   usePreviewInsertRowLazyQuery,
   useTagListQuery,
 } from "@gen/graphql-types";
 import useDatabaseDetails from "@hooks/useDatabaseDetails";
-import useSqlBuilder from "@hooks/useSqlBuilder";
+import useMutation from "@hooks/useMutation";
 import {
   TableOptionalSchemaParams,
   UploadParamsWithOptions,
 } from "@lib/params";
-import { table } from "@lib/urls";
+import { refetchUpdateDatabaseQueriesCacheEvict } from "@lib/refetchQueries";
+import { ref, table } from "@lib/urls";
 import { AiOutlineCode } from "@react-icons/all-files/ai/AiOutlineCode";
 import { AiOutlineDelete } from "@react-icons/all-files/ai/AiOutlineDelete";
 import { FiUpload } from "@react-icons/all-files/fi/FiUpload";
 import { ImTable2 } from "@react-icons/all-files/im/ImTable2";
+import { useRouter } from "next/router";
 import OptionSquare from "./OptionSquare";
 import css from "./index.module.css";
 import { mapColTypeToFakeValue } from "./utils";
@@ -32,11 +36,13 @@ type InnerProps = Props & {
 };
 
 function Inner(props: InnerProps) {
-  const { executeQuery, setEditorString, setError, toggleSqlEditor } =
+  const { setEditorString, setError, setExecutionMessage, toggleSqlEditor } =
     useSqlEditorContext();
-  const { dropTable } = useSqlBuilder();
   const { columns } = useDataTableContext();
   const [previewInsertRow] = usePreviewInsertRowLazyQuery();
+  const { mutateFn: dropTable } = useMutation({ hook: useDropTableMutation });
+  const client = useApolloClient();
+  const router = useRouter();
 
   const uploadParams: UploadParamsWithOptions = {
     ...props.params,
@@ -65,10 +71,18 @@ function Inner(props: InnerProps) {
   };
 
   const onDrop = async () => {
-    await executeQuery({
-      ...props.params,
-      query: dropTable(props.params.tableName),
-    });
+    const res = await dropTable({ variables: props.params });
+    if (res.success && res.data?.dropTable) {
+      setEditorString(res.data.dropTable.queryString);
+      setExecutionMessage(res.data.dropTable.executionMessage);
+      client
+        .refetchQueries(refetchUpdateDatabaseQueriesCacheEvict)
+        .catch(console.error);
+      const { href, as } = ref(props.params);
+      router.push(href, as).catch(console.error);
+    } else if (res.error) {
+      setError(res.error);
+    }
   };
 
   return (

--- a/web/renderer/components/pageComponents/DatabasePage/ForTable/queries.ts
+++ b/web/renderer/components/pageComponents/DatabasePage/ForTable/queries.ts
@@ -17,3 +17,23 @@ export const PREVIEW_INSERT_ROW = gql`
     )
   }
 `;
+
+export const DROP_TABLE = gql`
+  mutation DropTable(
+    $databaseName: String!
+    $refName: String!
+    $schemaName: String
+    $tableName: String!
+  ) {
+    dropTable(
+      databaseName: $databaseName
+      refName: $refName
+      schemaName: $schemaName
+      tableName: $tableName
+    ) {
+      rowsAffected
+      queryString
+      executionMessage
+    }
+  }
+`;

--- a/web/renderer/gen/graphql-types.tsx
+++ b/web/renderer/gen/graphql-types.tsx
@@ -258,6 +258,8 @@ export type Mutation = {
   deleteRow: MutationResult;
   deleteTag: Scalars['Boolean']['output'];
   doltClone: Scalars['Boolean']['output'];
+  dropColumn: MutationResult;
+  dropTable: MutationResult;
   fetchRemote: FetchRes;
   insertRow: MutationResult;
   loadDataFile: Scalars['Boolean']['output'];
@@ -357,6 +359,23 @@ export type MutationDoltCloneArgs = {
   databaseName: Scalars['String']['input'];
   ownerName: Scalars['String']['input'];
   remoteDbName: Scalars['String']['input'];
+};
+
+
+export type MutationDropColumnArgs = {
+  columnName: Scalars['String']['input'];
+  databaseName: Scalars['String']['input'];
+  refName: Scalars['String']['input'];
+  schemaName?: InputMaybe<Scalars['String']['input']>;
+  tableName: Scalars['String']['input'];
+};
+
+
+export type MutationDropTableArgs = {
+  databaseName: Scalars['String']['input'];
+  refName: Scalars['String']['input'];
+  schemaName?: InputMaybe<Scalars['String']['input']>;
+  tableName: Scalars['String']['input'];
 };
 
 
@@ -1107,6 +1126,17 @@ export type UpdateRowMutationVariables = Exact<{
 
 export type UpdateRowMutation = { __typename?: 'Mutation', updateRow: { __typename?: 'MutationResult', rowsAffected: number, queryString: string, executionMessage: string } };
 
+export type DropColumnMutationVariables = Exact<{
+  databaseName: Scalars['String']['input'];
+  refName: Scalars['String']['input'];
+  schemaName?: InputMaybe<Scalars['String']['input']>;
+  tableName: Scalars['String']['input'];
+  columnName: Scalars['String']['input'];
+}>;
+
+
+export type DropColumnMutation = { __typename?: 'Mutation', dropColumn: { __typename?: 'MutationResult', rowsAffected: number, queryString: string, executionMessage: string } };
+
 export type CreateDatabaseMutationVariables = Exact<{
   databaseName: Scalars['String']['input'];
 }>;
@@ -1715,6 +1745,16 @@ export type PreviewInsertRowQueryVariables = Exact<{
 
 
 export type PreviewInsertRowQuery = { __typename?: 'Query', previewInsertRow: string };
+
+export type DropTableMutationVariables = Exact<{
+  databaseName: Scalars['String']['input'];
+  refName: Scalars['String']['input'];
+  schemaName?: InputMaybe<Scalars['String']['input']>;
+  tableName: Scalars['String']['input'];
+}>;
+
+
+export type DropTableMutation = { __typename?: 'Mutation', dropTable: { __typename?: 'MutationResult', rowsAffected: number, queryString: string, executionMessage: string } };
 
 export type TestListQueryVariables = Exact<{
   databaseName: Scalars['String']['input'];
@@ -2472,6 +2512,51 @@ export function useUpdateRowMutation(baseOptions?: Apollo.MutationHookOptions<Up
 export type UpdateRowMutationHookResult = ReturnType<typeof useUpdateRowMutation>;
 export type UpdateRowMutationResult = Apollo.MutationResult<UpdateRowMutation>;
 export type UpdateRowMutationOptions = Apollo.BaseMutationOptions<UpdateRowMutation, UpdateRowMutationVariables>;
+export const DropColumnDocument = gql`
+    mutation DropColumn($databaseName: String!, $refName: String!, $schemaName: String, $tableName: String!, $columnName: String!) {
+  dropColumn(
+    databaseName: $databaseName
+    refName: $refName
+    schemaName: $schemaName
+    tableName: $tableName
+    columnName: $columnName
+  ) {
+    rowsAffected
+    queryString
+    executionMessage
+  }
+}
+    `;
+export type DropColumnMutationFn = Apollo.MutationFunction<DropColumnMutation, DropColumnMutationVariables>;
+
+/**
+ * __useDropColumnMutation__
+ *
+ * To run a mutation, you first call `useDropColumnMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDropColumnMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [dropColumnMutation, { data, loading, error }] = useDropColumnMutation({
+ *   variables: {
+ *      databaseName: // value for 'databaseName'
+ *      refName: // value for 'refName'
+ *      schemaName: // value for 'schemaName'
+ *      tableName: // value for 'tableName'
+ *      columnName: // value for 'columnName'
+ *   },
+ * });
+ */
+export function useDropColumnMutation(baseOptions?: Apollo.MutationHookOptions<DropColumnMutation, DropColumnMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DropColumnMutation, DropColumnMutationVariables>(DropColumnDocument, options);
+      }
+export type DropColumnMutationHookResult = ReturnType<typeof useDropColumnMutation>;
+export type DropColumnMutationResult = Apollo.MutationResult<DropColumnMutation>;
+export type DropColumnMutationOptions = Apollo.BaseMutationOptions<DropColumnMutation, DropColumnMutationVariables>;
 export const CreateDatabaseDocument = gql`
     mutation CreateDatabase($databaseName: String!) {
   createDatabase(databaseName: $databaseName)
@@ -4927,6 +5012,49 @@ export type PreviewInsertRowQueryHookResult = ReturnType<typeof usePreviewInsert
 export type PreviewInsertRowLazyQueryHookResult = ReturnType<typeof usePreviewInsertRowLazyQuery>;
 export type PreviewInsertRowSuspenseQueryHookResult = ReturnType<typeof usePreviewInsertRowSuspenseQuery>;
 export type PreviewInsertRowQueryResult = Apollo.QueryResult<PreviewInsertRowQuery, PreviewInsertRowQueryVariables>;
+export const DropTableDocument = gql`
+    mutation DropTable($databaseName: String!, $refName: String!, $schemaName: String, $tableName: String!) {
+  dropTable(
+    databaseName: $databaseName
+    refName: $refName
+    schemaName: $schemaName
+    tableName: $tableName
+  ) {
+    rowsAffected
+    queryString
+    executionMessage
+  }
+}
+    `;
+export type DropTableMutationFn = Apollo.MutationFunction<DropTableMutation, DropTableMutationVariables>;
+
+/**
+ * __useDropTableMutation__
+ *
+ * To run a mutation, you first call `useDropTableMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDropTableMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [dropTableMutation, { data, loading, error }] = useDropTableMutation({
+ *   variables: {
+ *      databaseName: // value for 'databaseName'
+ *      refName: // value for 'refName'
+ *      schemaName: // value for 'schemaName'
+ *      tableName: // value for 'tableName'
+ *   },
+ * });
+ */
+export function useDropTableMutation(baseOptions?: Apollo.MutationHookOptions<DropTableMutation, DropTableMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DropTableMutation, DropTableMutationVariables>(DropTableDocument, options);
+      }
+export type DropTableMutationHookResult = ReturnType<typeof useDropTableMutation>;
+export type DropTableMutationResult = Apollo.MutationResult<DropTableMutation>;
+export type DropTableMutationOptions = Apollo.BaseMutationOptions<DropTableMutation, DropTableMutationVariables>;
 export const TestListDocument = gql`
     query TestList($databaseName: String!, $refName: String!) {
   tests(databaseName: $databaseName, refName: $refName) {


### PR DESCRIPTION
Can't use `queryBuilder` for DDL statements so I'm just doing it manually here. There might be a way to still TypeORM-ify it but it looked overly complicated for such simple statements like `DROP TABLE x`.