### PR TITLE
Update docs links to dolthub.com/docs

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -230,7 +230,7 @@ http {
 
 The `X-Forwarded-User` and `X-Forwarded-Email` headers are passed through to the workbench
 and can used as the
-[author](https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures#options-6)
+[author](https://dolthub.com/docs/sql-reference/version-control/dolt-sql-procedures#options-6)
 when creating a commit. Simply check the "Use name and email from headers as commit
 author" checkbox. The commit will be created with the user and email.
 

--- a/web/main/helpers/menu.ts
+++ b/web/main/helpers/menu.ts
@@ -174,7 +174,7 @@ export function initMenu(
         {
           label: "Documentation",
           async click() {
-            await shell.openExternal("https://docs.dolthub.com/");
+            await shell.openExternal("https://dolthub.com/docs/");
           },
         },
         {

--- a/web/renderer/components/Views/index.test.tsx
+++ b/web/renderer/components/Views/index.test.tsx
@@ -34,7 +34,7 @@ describe("tests Views", () => {
     expect(link).toHaveTextContent("Add some");
     expect(link).toHaveProperty(
       "href",
-      "https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables#dolt_schemas",
+      "https://dolthub.com/docs/sql-reference/version-control/dolt-system-tables#dolt_schemas",
     );
   });
 

--- a/web/renderer/components/pageComponents/DatabasePage/ForRemotes/AddRemotePage/AddRemoteForm.tsx
+++ b/web/renderer/components/pageComponents/DatabasePage/ForRemotes/AddRemotePage/AddRemoteForm.tsx
@@ -101,7 +101,7 @@ export default function AddRemoteForm(props: Props): JSX.Element {
             A remote is a {dbLink} database in another location, usually on a
             different, network accessible host. To learn more about configuring
             a remote for your database, see our{" "}
-            <Link href="https://docs.dolthub.com/concepts/dolt/git/remotes">
+            <Link href="https://dolthub.com/docs/concepts/dolt/git/remotes">
               documentation
             </Link>
           </p>

--- a/web/renderer/components/pageComponents/DatabasePage/ForRemotes/RemotesPage/DoltLoginButton.tsx
+++ b/web/renderer/components/pageComponents/DatabasePage/ForRemotes/RemotesPage/DoltLoginButton.tsx
@@ -120,7 +120,7 @@ function Inner({ connection }: InnerProps) {
                 dolt login authenticates your local dolt client to DoltHub.com,
                 associates your client with your DoltHub identity. To learn more
                 about dolt login, see our{" "}
-                <Link href="https://docs.dolthub.com/cli-reference/cli#dolt-login">
+                <Link href="https://dolthub.com/docs/cli-reference/cli#dolt-login">
                   documentation
                 </Link>
                 .

--- a/web/renderer/lib/constants.ts
+++ b/web/renderer/lib/constants.ts
@@ -1,5 +1,5 @@
 export const discordLink = "https://discord.gg/gqr7K4VNKe";
-export const docsLink = "https://docs.dolthub.com";
+export const docsLink = "https://dolthub.com/docs";
 export const doltGithubRepo = "https://github.com/dolthub/dolt";
 export const doltgresGithubRepo = "https://github.com/dolthub/doltgresql";
 export const workbenchGithubRepo = "https://github.com/dolthub/dolt-workbench";


### PR DESCRIPTION
Migrate all `docs.dolthub.com` references to the new `dolthub.com/docs` URL across the workbench source.

